### PR TITLE
Also run image pushing on push trigger

### DIFF
--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -27,7 +27,7 @@ jobs:
   push-encfs-image:
     name: Push Encrypted FS Image
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -27,7 +27,7 @@ jobs:
   push-encfs-image:
     name: Push Encrypted FS Image
     runs-on: ubuntu-latest
-    if: ${{ github.event == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/push_skr_debug_image.yml
+++ b/.github/workflows/push_skr_debug_image.yml
@@ -28,7 +28,7 @@ jobs:
   push-skr-debug-image: 
     name: Push SKR Debug Image
     runs-on: ubuntu-latest
-    if: ${{ github.event == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/push_skr_debug_image.yml
+++ b/.github/workflows/push_skr_debug_image.yml
@@ -28,7 +28,7 @@ jobs:
   push-skr-debug-image: 
     name: Push SKR Debug Image
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/push_skr_image.yml
+++ b/.github/workflows/push_skr_image.yml
@@ -26,7 +26,7 @@ jobs:
   push-skr-image:
     name: Push SKR Image
     runs-on: ubuntu-latest
-    if: ${{ github.event == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/push_skr_image.yml
+++ b/.github/workflows/push_skr_image.yml
@@ -26,7 +26,7 @@ jobs:
   push-skr-image:
     name: Push SKR Image
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The change which introduces a check to skip the image pushing workflows if coming from an external fork also skips when the event is push, this fixes that