### PR TITLE
Use URL base64 encoding

### DIFF
--- a/cmd/azmount/filemanager/azure.go
+++ b/cmd/azmount/filemanager/azure.go
@@ -30,7 +30,7 @@ func tokenRefresher(credential azblob.TokenCredential) (t time.Duration) {
 	// JWT tokens comprise three fields. the second field is the payload (or claims).
 	// we care about the `aud` attribute of the payload
 	curentTokenFields := strings.Split(currentToken, ".")
-	payload, _ := base64.StdEncoding.DecodeString(curentTokenFields[1])
+	payload, _ := base64.RawURLEncoding.DecodeString(curentTokenFields[1])
 	var payloadMap map[string]interface{}
 	json.Unmarshal([]byte(payload), &payloadMap)
 	audience := payloadMap["aud"].(string)


### PR DESCRIPTION
From original PR:

> Changing the Decoding type to Raw URL encoding.
> 
> JWTs make use of the base64url encoding as defined in [RFC 4648](https://www.ietf.org/archive/id/draft-jones-json-web-token-02.html#RFC4648) [RFC4648]. As allowed by Section 3.2 of the RFC, this specification mandates that base64url encoding when used with JWTs MUST NOT use padding. The reason for this restriction is that the padding character ('=') is not URL safe. [https://www.ietf.org/archive/id/draft-jones-json-web-token-02.html#rfc.section.7)].
> 
> The base64 Std / URL parsers expect a padding character (=), which is optional and the absence of which can lead to unexpected failures. (https://pkg.go.dev/encoding/base64). There is a github issue which talks about the same - https://github.com/golang/go/issues/46257