### PR TITLE
allowPriviledgeEscalation is behind a feature flag and not generally …

### DIFF
--- a/examples/encfs/aci-arm-template.json
+++ b/examples/encfs/aci-arm-template.json
@@ -38,8 +38,7 @@
               ],
               "image": "mcr.microsoft.com/aci/encfs:2.2",
               "securityContext": {
-                "privileged": true,
-                "allowPrivilegeEscalation": true  
+                "privileged": true
               },
               "resources": {
                 "requests": {


### PR DESCRIPTION
allowPriviledgeEscalation is behind a feature flag and not generally available. It is not required for this use case.