### PR TITLE
Reduce docker layers

### DIFF
--- a/docker/encfs/Dockerfile.encfs
+++ b/docker/encfs/Dockerfile.encfs
@@ -1,6 +1,6 @@
 FROM alpine:3.17.1
 
-RUN apk update && apk add cryptsetup fuse curl
+RUN apk update && apk add --no-cache cryptsetup fuse curl
 
 COPY ./bin/azmount ./bin/remotefs ./bin/get-snp-report /bin/
 COPY encfs.sh /

--- a/docker/skr/Dockerfile.skr
+++ b/docker/skr/Dockerfile.skr
@@ -1,11 +1,10 @@
 FROM alpine:3.17.1
 
-RUN apk update && apk add curl
+RUN apk update && apk add --no-cache curl
 
 COPY ./bin/skr ./bin/get-snp-report /bin/
 COPY skr.sh tests/*_client.sh tests/skr_test.sh /
-RUN mkdir -p /tests/skr; mv *_client.sh /tests/skr; mv skr_test.sh /tests/skr
-RUN chmod +x /*.sh /tests/skr/*.sh; date > /made-date
+RUN mkdir -p /tests/skr; mv *_client.sh /tests/skr; mv skr_test.sh /tests/skr && chmod +x /*.sh /tests/skr/*.sh
 
 # set the start command
 CMD [ "sleep", "1000000" ]


### PR DESCRIPTION
Reduce the number of layers in the SKR and encfs container.  Also make the images smaller by disabling APK caching in both.