### PR TITLE
Prevent sanitised tags being cleaned up

### DIFF
--- a/.github/workflows/cleanup_registry.yml
+++ b/.github/workflows/cleanup_registry.yml
@@ -24,7 +24,7 @@ jobs:
           REGISTRY_NAME: ${{ secrets.REGISTRY_NAME }}
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         run: |
-          repos=("skr" "skr_debug" "encfs")
+          repos=("skr" "skr_debug" "encfs" "attestation")
           branches=$(git ls-remote --heads origin | sed 's/[^a-zA-Z0-9]/-/g')
           
           # Delete any tags which don't have a corresponding branch

--- a/.github/workflows/cleanup_registry.yml
+++ b/.github/workflows/cleanup_registry.yml
@@ -25,7 +25,7 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         run: |
           repos=("skr" "skr_debug" "encfs")
-          branches=$(git ls-remote --heads origin)
+          branches=$(git ls-remote --heads origin | sed 's/[^a-zA-Z0-9]/-/g')
           
           # Delete any tags which don't have a corresponding branch
           for repo in "${repos[@]}"; do


### PR DESCRIPTION
Since we started sanitising branch names when making the tag to upload images with, we didn't update the logic for cleaning up tags which no longer have a corresponding branch, so any image with a sanitised name is always cleaned up.

Fix is to sanitise all branch names in the same way before checking if a tag matches any of them