### PR TITLE
Allow push image workflows to be run manually

### DIFF
--- a/.github/workflows/push_attestation_image.yml
+++ b/.github/workflows/push_attestation_image.yml
@@ -47,9 +47,11 @@ jobs:
         run: |
           if [ ${{ github.event_name }} == "push" ]; then
             branch_name=main
-          else
+          elif [ ${{ github.event_name }} == "workflow_dispatch" ]; then
             branch_name=${{ github.ref }}
             branch_name=${branch_name:11}
+          else
+            branch_name=${{ github.head_ref }}
           fi
           echo $branch_name
           echo "image_tag=$(echo ${branch_name:0:128} | sed 's/[^a-zA-Z0-9]/-/g')" >> $GITHUB_OUTPUT

--- a/.github/workflows/push_attestation_image.yml
+++ b/.github/workflows/push_attestation_image.yml
@@ -30,7 +30,7 @@ jobs:
   push-attestation-image:
     name: Push Attestation Image
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/push_attestation_image.yml
+++ b/.github/workflows/push_attestation_image.yml
@@ -47,12 +47,10 @@ jobs:
         run: |
           if [ ${{ github.event_name }} == "push" ]; then
             branch_name=main
-          elif [ ${{ github.event_name }} == "workflow_dispatch" ]; then
-            branch_name=${{ github.ref }}
-            echo $branch_name
           else
-            branch_name=${{ github.head_ref }}
+            branch_name=${{ github.ref:11 }}
           fi
+          echo $branch_name
           echo "image_tag=$(echo ${branch_name:0:128} | sed 's/[^a-zA-Z0-9]/-/g')" >> $GITHUB_OUTPUT
 
       - name: Build and Push Docker Image

--- a/.github/workflows/push_attestation_image.yml
+++ b/.github/workflows/push_attestation_image.yml
@@ -48,7 +48,8 @@ jobs:
           if [ ${{ github.event_name }} == "push" ]; then
             branch_name=main
           else
-            branch_name=${{ github.ref:11 }}
+            branch_name=${{ github.ref }}
+            branch_name=${branch_name:11}
           fi
           echo $branch_name
           echo "image_tag=$(echo ${branch_name:0:128} | sed 's/[^a-zA-Z0-9]/-/g')" >> $GITHUB_OUTPUT

--- a/.github/workflows/push_attestation_image.yml
+++ b/.github/workflows/push_attestation_image.yml
@@ -53,7 +53,6 @@ jobs:
           else
             branch_name=${{ github.head_ref }}
           fi
-          echo $branch_name
           echo "image_tag=$(echo ${branch_name:0:128} | sed 's/[^a-zA-Z0-9]/-/g')" >> $GITHUB_OUTPUT
 
       - name: Build and Push Docker Image

--- a/.github/workflows/push_attestation_image.yml
+++ b/.github/workflows/push_attestation_image.yml
@@ -47,7 +47,10 @@ jobs:
         run: |
           if [ ${{ github.event_name }} == "push" ]; then
             branch_name=main
-          else  
+          elif [ ${{ github.event_name }} == "workflow_dispatch" ]; then
+            branch_name=${{ github.ref }}
+            echo $branch_name
+          else
             branch_name=${{ github.head_ref }}
           fi
           echo "image_tag=$(echo ${branch_name:0:128} | sed 's/[^a-zA-Z0-9]/-/g')" >> $GITHUB_OUTPUT

--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -50,6 +50,9 @@ jobs:
         run: |
           if [ ${{ github.event_name }} == "push" ]; then
             branch_name=main
+          elif [ ${{ github.event_name }} == "workflow_dispatch" ]; then
+            branch_name=${{ github.ref }}
+            branch_name=${branch_name:11}
           else  
             branch_name=${{ github.head_ref }}
           fi

--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -31,7 +31,7 @@ jobs:
   push-encfs-image:
     name: Push Encrypted FS Image
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/push_skr_debug_image.yml
+++ b/.github/workflows/push_skr_debug_image.yml
@@ -51,6 +51,9 @@ jobs:
         run: |
           if [ ${{ github.event_name }} == "push" ]; then
             branch_name=main
+          elif [ ${{ github.event_name }} == "workflow_dispatch" ]; then
+            branch_name=${{ github.ref }}
+            branch_name=${branch_name:11}
           else  
             branch_name=${{ github.head_ref }}
           fi

--- a/.github/workflows/push_skr_debug_image.yml
+++ b/.github/workflows/push_skr_debug_image.yml
@@ -32,7 +32,7 @@ jobs:
   push-skr-debug-image:
     name: Push SKR Debug Image
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/push_skr_image.yml
+++ b/.github/workflows/push_skr_image.yml
@@ -30,7 +30,7 @@ jobs:
   push-skr-image:
     name: Push SKR Image
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/push_skr_image.yml
+++ b/.github/workflows/push_skr_image.yml
@@ -49,6 +49,9 @@ jobs:
         run: |
           if [ ${{ github.event_name }} == "push" ]; then
             branch_name=main
+          elif [ ${{ github.event_name }} == "workflow_dispatch" ]; then
+            branch_name=${{ github.ref }}
+            branch_name=${branch_name:11}
           else  
             branch_name=${{ github.head_ref }}
           fi


### PR DESCRIPTION
This will allow us to manually re-run image pushing workflows for PRs (Still can't run against fork PRs)