### PR TITLE
Fixed mismatched flag names between skr shell script and skr go code

### DIFF
--- a/docker/skr/skr.sh
+++ b/docker/skr/skr.sh
@@ -29,11 +29,11 @@ fi
 
 # LogFile and LogLevel are expected to be passed in as environment variables
 if [ -n "${LogFile}" ]; then
-  CmdlineArgs="${CmdlineArgs} -logFile ${LogFile}"
+  CmdlineArgs="${CmdlineArgs} -logfile ${LogFile}"
 fi
 
 if [ -n "${LogLevel}" ]; then
-  CmdlineArgs="${CmdlineArgs} -logLevel ${LogLevel}"
+  CmdlineArgs="${CmdlineArgs} -loglevel ${LogLevel}"
 fi
 
 echo CmdlineArgs = $CmdlineArgs


### PR DESCRIPTION
Description:
`docker/skr/skr.sh` constructs command-line arguments using the `-logFile` and `-logLevel` flags, but `cmd/skr/main.go` parses `-logfile` and `-loglevel` flags. The flags are case-sensitive, so if a user specifies either of these logging parameters in their ARM template, the skr container will not run.

Solution:
Made the logging flags in `docker/skr/skr.sh` and `cmd/skr/main.go` consistent.

Changes:
In `docker/skr/skr.sh`, modified `-logFile` to `-logfile` and `-logLevel` to `-loglevel` to align with the flag names defined in `cmd/skr/main.go`.

Testing:
Rebuilt the skr image with the change and deployed the skr container with logging specified in the ARM template. The skr container now runs.