### PR TITLE
revert hexstring.py removal change. 

### DIFF
--- a/examples/encfs/generatefs/generatefs.sh
+++ b/examples/encfs/generatefs/generatefs.sh
@@ -18,6 +18,8 @@ fi
 
 echo "Key in hex string format"
 
+python hexstring.py $keyFilePath
+
 truncate -s 32 "$keyFilePath"
 
 echo "[!] Creating encrypted image..."

--- a/examples/encfs/generatefs/hexstring.py
+++ b/examples/encfs/generatefs/hexstring.py
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import binascii
+import sys
+
+if len(sys.argv) != 2:
+    print("Usage: python hexstring.py <filename>")
+    sys.exit(-1)
+
+bFile = open(sys.argv[1],'rb') 
+bData = bFile.read(32)
+print(binascii.hexlify(bData))

--- a/tools/importkey/README.MD
+++ b/tools/importkey/README.MD
@@ -38,7 +38,7 @@ When importing a key to the key vault, a release policy is coupled with the key.
         {
             "claim": "x-ms-sevsnpvm-is-debuggable",
             "equals": "false"
-        }            
+        }
     ]
 }
 ```
@@ -53,7 +53,7 @@ The tool currently supports two types of keys specified in the `kty` attribute o
 
 - -kh
 
-    Path for octet key (optional)
+    Path for octet key or contents of octet key (optional)
 
 - -kp
 

--- a/tools/importkey/main.go
+++ b/tools/importkey/main.go
@@ -62,7 +62,7 @@ func main() {
 
 	// flags declaration using flag package
 	flag.StringVar(&configFile, "c", "", "Specify config file to process")
-	flag.StringVar(&keyHexFile, "kh", "", "Specify path to oct key file [optional]")
+	flag.StringVar(&keyHexFile, "kh", "", "Specify path to oct key file or the contents of the oct key [optional]")
 	flag.StringVar(&keyRSAPEMFile, "kp", "", "Specify path to RSA key PEM file [optional]")
 	flag.BoolVar(&runInsideAzure, "a", false, "Run within Azure VM [optional]")
 	flag.BoolVar(&outputOctetKeyfile, "out", false, "Output octet key binary file")
@@ -241,6 +241,13 @@ func main() {
 		if keyHexFile == "" {
 			octKey = make([]byte, 32)
 			rand.Read(octKey)
+		} else if _, err = os.Stat(keyHexFile); err != nil {
+			// read string keyHexFile as contents of the key
+			octKey, err = hex.DecodeString(keyHexFile)
+			if err != nil {
+				fmt.Println(err)
+				return
+			}
 		} else {
 			// read string from file keyHexFile as hexstring
 			octKey, err = os.ReadFile(keyHexFile)


### PR DESCRIPTION
Sacket complained the change broke customers' existing scripts. His blog also depends on this script. We need to provide backward compatibility. Bryce wanted us to put it back. 