### PR TITLE
Change skr base image to Mariner

### DIFF
--- a/docker/skr/Dockerfile.skr
+++ b/docker/skr/Dockerfile.skr
@@ -8,12 +8,17 @@ RUN cd tools/get-snp-report && make && mv bin/get-snp-report / && mv bin/get-fak
 
 RUN cd cmd/skr && CGO_ENABLED=0 GOOS=linux go build -o /skr -ldflags="-s -w" main.go
 
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+
+RUN tdnf upgrade && tdnf install -y ca-certificates && tdnf clean all
 
 COPY --from=build /skr /get-snp-report /get-fake-snp-report ./bin/
 
 ENV BUILD_DIR=/go/src/github.com/microsoft/confidential-sidecar-containers
 COPY --from=build ${BUILD_DIR}/docker/skr/skr.sh /
+COPY --from=build ${BUILD_DIR}/docker/skr/tests/*_client.sh ${BUILD_DIR}/docker/skr/tests/skr_test.sh /tests/skr/
+
+RUN chmod +x /*.sh /tests/skr/*.sh
 
 # set the start command
 CMD [ "/skr.sh" ]

--- a/docker/skr/Dockerfile.skr
+++ b/docker/skr/Dockerfile.skr
@@ -8,17 +8,12 @@ RUN cd tools/get-snp-report && make && mv bin/get-snp-report / && mv bin/get-fak
 
 RUN cd cmd/skr && CGO_ENABLED=0 GOOS=linux go build -o /skr -ldflags="-s -w" main.go
 
-FROM alpine:3.18.4
-
-RUN apk update && apk upgrade --no-cache && apk add --no-cache curl
+FROM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
 
 COPY --from=build /skr /get-snp-report /get-fake-snp-report ./bin/
 
 ENV BUILD_DIR=/go/src/github.com/microsoft/confidential-sidecar-containers
 COPY --from=build ${BUILD_DIR}/docker/skr/skr.sh /
-COPY --from=build ${BUILD_DIR}/docker/skr/tests/*_client.sh ${BUILD_DIR}/docker/skr/tests/skr_test.sh /tests/skr/
-
-RUN chmod +x /*.sh /tests/skr/*.sh
 
 # set the start command
 CMD [ "/skr.sh" ]

--- a/pkg/common/maa.go
+++ b/pkg/common/maa.go
@@ -174,7 +174,7 @@ func (maa MAA) Attest(SNPReportHexBytes []byte, vcekCertChain []byte, policyBlob
 	if err != nil {
 		// added debug information if needed
 		if httpResponse != nil && httpResponse.Header != nil && httpResponse.Header.Get("x-ms-request-id") != "" {
-			logrus.Debugf("MAA Response header: %s", httpResponse.Header.Get("x-ms-request-id"))
+			logrus.Infof("MAA Request ID: %s", httpResponse.Header.Get("x-ms-request-id"))
 		}
 		return "", errors.Wrapf(err, "maa post request failed")
 	}

--- a/pkg/common/maa.go
+++ b/pkg/common/maa.go
@@ -172,6 +172,10 @@ func (maa MAA) Attest(SNPReportHexBytes []byte, vcekCertChain []byte, policyBlob
 	logrus.Debugf("Posting MAA Attestation Request to %s", uri)
 	httpResponse, err := HTTPPRequest("POST", uri, maaRequestJSONData, "")
 	if err != nil {
+		// added debug information if needed
+		if httpResponse != nil && httpResponse.Header != nil && httpResponse.Header.Get("x-ms-request-id") != "" {
+			logrus.Debugf("MAA Response header: %s", httpResponse.Header.Get("x-ms-request-id"))
+		}
 		return "", errors.Wrapf(err, "maa post request failed")
 	}
 


### PR DESCRIPTION
Changing base image for SKR image to Mariner to be in line with Azure updates. 

Putting in draft mode for now until the kernel is patched in ACI to allow for exec-ing into this image