### PR TITLE
Turning the gRPC server off by default

### DIFF
--- a/examples/aasp/aasp-sample-template.yaml
+++ b/examples/aasp/aasp-sample-template.yaml
@@ -10,13 +10,21 @@ spec:
   containers:
   - image: $AASP_IMAGE
     imagePullPolicy: Always
+<<<<<<< HEAD:examples/aasp/aasp-sample-template.yaml
     name: aasp
     command: [/bin/aasp]
+=======
+    name: skr
+    command:
+    - /skr.sh
+>>>>>>> e46223c (making the grpc server off by default):examples/skr/aks/skr-example-template.yaml
     env:
     - name: AaspSideCarArgs
       value: ewogICAgImNlcnRjYWNoZSI6IHsKCQkiZW5kcG9pbnRfdHlwZSI6ICJMb2NhbFRISU0iLAoJCSJlbmRwb2ludCI6ICIxNjkuMjU0LjE2OS4yNTQvbWV0YWRhdGEvVEhJTS9hbWQvY2VydGlmaWNhdGlvbiIKCX0gIAp9
     - name: UVM_SECURITY_CONTEXT_DIR
       value: /opt/confidential-containers/share/kata-containers
+    - name: KEYPROVIDER_SOCK
+      value: 127.0.0.1:50000
     volumeMounts:
     - mountPath: /opt/confidential-containers/share/kata-containers/reference-info-base64
       name: endorsement-location

--- a/examples/skr/aks/README.md
+++ b/examples/skr/aks/README.md
@@ -1,0 +1,228 @@
+# Microsoft Secure Key Release (SKR) AKS Example
+
+- [Introduction](#introduction)
+- [Export Environment Variables](#export-environment-variables)
+- [Secret Provisioning Workflow Step By Step](#secret-provisioning-workflow)
+  - [1. Create a mHSM Instance](#1-create-a-mhsm-instance)
+  - [2. Obtain an Attestation Endpoint](#2-obtain-an-attestation-endpoint)
+  - [3. Generate a Key Pair](#3-generate-a-key-pair)
+  - [4. Generate a Wrapped Secret](#4-generate-a-wrapped-secret)
+  - [5. Create a Federated Credential Identity](#5-create-a-federated-credential-identity)
+  - [6. Build Required Container Images](#6-build-required-container-images)
+  - [7. Running the SKR Container in a TEE](#7-running-the-skr-container-in-a-tee)
+  - [8. Unwrap the Secret Using grpcurl](#8-unwrap-the-secret-using-grpcurl)
+
+## Introduction
+
+This guide provides instructions on how to perform secret provisioning in AKS using the SKR container.
+By following these instructions, users can ensure that their secrets are securely stored and can be used by their applications.
+
+## Export Environment Variables
+
+```bash
+export SKR_IMAGE=<skr-image-name>
+export EXAMPLE_UNWRAP_IMAGE=<example-unwrap-image-name>
+export RESOURCE_GROUP=<resource-group-name>
+export USER_ASSIGNED_IDENTITY_NAME=<identity-name>
+export LOCATION=<location>
+export SUBSCRIPTION="$(az account show --query id --output tsv)"
+export SERVICE_ACCOUNT_NAME=<service-account-name>
+export SERVICE_ACCOUNT_NAMESPACE="default"
+export FEDERATED_CREDENTIAL_IDENTITY_NAME=<federated-credential-identity-name>
+```
+
+## Secret Provisioning Workflow
+
+### 1. Create a mHSM Instance
+
+Users must have a functioning mHSM to store the private key and its associated release policy.
+The release policy describes the conditions the key release request must meet in order for the mhsm to release the key.
+
+To set up a mHSM instance, follow the instructions [here with Azure CLI](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/quick-create-cli),
+or through the [Azure portal](https://ms.portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.KeyVault%2FmanagedHSMs).
+You can follow the installation instructions for Azure CLI [here](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli).
+
+### 2. Obtain an Attestation Endpoint
+
+Users must have a working attestation endpoint to interact with the mHSM.
+
+If you don't already have a valid attestation endpoint, create a [Microsoft Azure Attestation](https://learn.microsoft.com/en-us/azure/attestation/overview) endpoint to author the attestation token and run the following command to get the endpoint value:
+
+```shell
+az attestation show --name "<ATTESTATION PROVIDER NAME>" --resource-group "<RESOURCE GROUP>"
+```
+
+### 3. Generate a Key Pair
+
+This is a one time effort.
+Once the key is created, it can be used to protect as many secrets as desired.
+
+The `setup-key-mhsm.sh` script creates a private/public key pair in the keyvault and a key release policy with the file name `keyname-release-policy.json`.
+The public key is then downloaded as `keyname-pub.pem` and a key info file is generated.
+Both the public key and the key info file are used for wrapping the secret.
+The script also assigns the necessary access role (Managed HSM Crypto User) to the Managed Identity.
+Depending on the operating system, make sure the end of line sequence(LF vs CRLF) is set correctly before running the script.
+
+`MANAGED_IDENTITY` has the following format:
+
+`/subscriptions/<subscription-id>/resourceGroups/<resource_group_name>/providers/Microsoft.ManagedIdentity/<userAssignedIdentities>/msi`
+
+`<key-name>`: just the name of the key such as `examplekey`
+
+`<mhsm>`: just the name of the mhsm instance without the `managedhsm.azure.net` part.
+For a mhsm instance with the full URL: `examplemhsm.managedhsm.azure.net`, the `mhsm` is just `examplemhsm`.
+
+```bash
+# Create a managed identity for accessing MHSM. Note the Principle ID of the identity
+az identity create -g $RESOURCE_GROUP -n $USER_ASSIGNED_IDENTITY_NAME | grep "id"
+# The following two exported env vars are used by the setup-key-mhsm.sh script
+export MANAGED_IDENTITY=<principle-id>
+export MAA_ENDPOINT=<maa-endpoint> # Choose a MAA instance for the attestation service, e.g. sharedeus2.eus2.attest.azure.net
+
+# Login
+az login
+# Set account context to the subscription where the mhsm resides
+az account set --subscription <subscription-name>
+# change the access permissions to execute of the script
+chmod +x setup-key-mhsm.sh
+# execute the script to generate key pair
+bash setup-key-mhsm.sh <key-name> <mhsm>
+```
+
+### 4. Generate a Wrapped Secret
+
+Build the SKR binary first:
+
+```bash
+go build -o skr ./cmd/skr/main.go
+```
+
+In the following example, the secret is stored in file [plaintext](plaintext).
+Assuming the name of the key we created in the above step is `testkey000`, we can generate a wrapped secret using the public key and store it in a file named wrapped (adjust the path to the key if necessary).
+This file will be used to unwrap the secret later.
+The wrapped file will be used to generate an argument that gets passed into grpcurl command to invoke the exposed gRPC APIs.
+
+```bash
+skr --infile plaintext --keypath ./testkey000 --outfile wrapped
+```
+
+### 5. Create a Federated Credential Identity
+
+```bash
+export AKS_OIDC_ISSUER="$(az aks show -n clusterName -g "${RESOURCE_GROUP}" --query "oidcIssuerProfile.issuerUrl" -otsv)"
+
+export USER_ASSIGNED_CLIENT_ID="$(az identity show --resource-group "${RESOURCE_GROUP}" --name "${USER_ASSIGNED_IDENTITY_NAME}" --query 'clientId' -otsv)"
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    azure.workload.identity/client-id: ${USER_ASSIGNED_CLIENT_ID}
+  name: ${SERVICE_ACCOUNT_NAME}
+  namespace: ${SERVICE_ACCOUNT_NAMESPACE}
+EOF
+# Create the federated credential identity between the managed identity, service account issuer, and subject using the az identity federated-credential create command.
+az identity federated-credential create --name ${FEDERATED_CREDENTIAL_IDENTITY_NAME} --identity-name ${USER_ASSIGNED_IDENTITY_NAME} --resource-group ${RESOURCE_GROUP} --issuer ${AKS_OIDC_ISSUER} --subject system:serviceaccount:${SERVICE_ACCOUNT_NAMESPACE}:${SERVICE_ACCOUNT_NAME}
+```
+
+### 6. Build Required Container Images
+
+In order to use grpcurl to call the exposed gRPC APIs to unwrap secrets, users must build the following two images:
+
+1. The `SKR container` image that hosts gRPC server. See [Dockerfile.build](../../docker/skr/Dockerfile.skr)
+2. A `example-unwrap` container image that has grpcurl installed and allows users to unwrap secrets. [Dockerfile.example](../../docker/skr/Dockerfile.example)
+
+To build the images, make sure you are in the root of confidential-sidecar-containers repo and run the following commands:
+
+```bash
+docker build -t $SKR_IMAGE -f docker/skr/Dockerfile.skr .
+docker build -t $EXAMPLE_UNWRAP_IMAGE -f docker/skr/Dockerfile.example .
+```
+
+Push the container images to your container registry.
+
+### 7. Running the SKR Container in a TEE
+
+Use the SKR container as a gRPC service during runtime to unwrap the secret with the private key stored in mHSM.
+This step ensures that the private key is securely retrieved in the SKR container and used for unwrapping the wrapped secret. Note that gRPC is off by default and the environment variable `KEYPROVIDER_SOCK` enables the gRPC server. An example `KEYPROVIDER_SOCK` value is `127.0.0.1:50000`.
+
+You can run an example deployment of a confidential pod with the `SKR` container and a `example-unwrap` container that invokes the secret provisioning APIs of the `SKR` container. Use the [example pod yaml file](skr-example-template.yaml) to deploy the pod. First, create an image pull secret (this example uses an Azure Container Registry) then deploy the pod with kubectl using the following command:
+
+```bash
+export $ACR_SECRET=<secret-name>
+kubectl create secret docker-registry $ACR_SECRET \
+    --namespace <namespace> \
+    --docker-server=<REGISTRY_NAME>.azurecr.io \
+    --docker-username=<appId> \
+    --docker-password=<password>
+
+envsubst < skr-example-template.yaml > skr-example.yaml
+
+kubectl apply -f skr-example.yaml
+```
+
+Issue the following command to shell into the example-unwrap container and issue grpcurl commands:
+
+```bash
+kubectl exec --stdin --tty skr-secret-provisioning -c example-unwrap -- /bin/sh
+
+# This command lists the services exposed on 127.0.0.1:50000
+grpcurl -v -plaintext 127.0.0.1:50000 list
+
+# This command lists the exposed APIs under KeyProviderService on port 127.0.0.1:50000
+grpcurl -v -plaintext 127.0.0.1:50000  list keyprovider.KeyProviderService
+
+# Call the SayHello service. We use the SayHello method to test whether APIs under KeyProviderService can be reached
+grpcurl -v -plaintext -d '{"name":"This is a GRPC test!"}' 127.0.0.1:50000  keyprovider.KeyProviderService.SayHello
+
+# Call the GetReport service to get the SNP report in hex string format. Users can optionally provide `reportDataHexString` and the input will show under report data section of the SNP report. This is used for detecting a replay attack.
+grpcurl -v -plaintext -d '{"reportDataHexString":""}' 127.0.0.1:50000  keyprovider.KeyProviderService.GetReport
+
+```
+
+### 8. Unwrap the Secret Using grpcurl
+
+While shelled into the example-unwrap container, make sure you are in the same directory as the `wrapped` file.
+Issue the following command to test whether the key can be released.
+
+```bash
+AAA=`printf skr | base64 -w0`
+
+ANNO=`cat wrapped`
+
+REQ=`echo "{\"op\":\"keyunwrap\",\"keywrapparams\":{},\"keyunwrapparams\":{\"dc\":{\"Parameters\":{\"attestation-agent\":[\"${AAA}\"]}},\"annotation\":\"${ANNO}\"}}" | base64 -w0`
+
+grpcurl -plaintext -d "{\"KeyProviderKeyWrapProtocolInput\":\"${REQ}\"}" 127.0.0.1:50000 keyprovider.KeyProviderService.UnWrapKey
+```
+
+Upon successful key release, you should see:
+
+```json
+Resolved method descriptor:
+rpc UnWrapKey ( .keyprovider.keyProviderKeyWrapProtocolInput ) returns ( .keyprovider.keyProviderKeyWrapProtocolOutput );
+
+Request metadata to send:
+(empty)
+
+Response headers received:
+content-type: application/grpc
+
+Response contents:
+{
+  "KeyProviderKeyWrapProtocolOutput": "eyJrZXl3cmFwcmVzdWx0cyI6eyJhbm5vdGF0aW9uIjpudWxsfSwia2V5dW53cmFwcmVzdWx0cyI6eyJvcHRzZGF0YSI6IlQyTmxZVzV6SUdGeVpTQm1kV3hzSUc5bUlIZGhkR1Z5RFFwSWIzSnpaWE1nYUdGMlpTQTBJR3hsWjNNTkNnPT0ifX0="
+}
+```
+
+Base64 decode the result to see the encrypted secret.
+
+```json
+{"keywrapresults":{"annotation":null},"keyunwrapresults":{"optsdata":"T2NlYW5zIGFyZSBmdWxsIG9mIHdhdGVyDQpIb3JzZXMgaGF2ZSA0IGxlZ3MNCg=="}}
+```
+
+Base64 decode the `optsdata` field to see the secret (the contents of the plaintext file).
+
+```
+Oceans are full of water
+Horses have 4 legs
+```


### PR DESCRIPTION
Having the gRPC server on by default on port 50000 might interfere with customer servers, so we can turn it off by default and enable it by setting the `KEYPROVIDER_SOCK` env var