### PR TITLE
Making grpc server optional

### DIFF
--- a/cmd/skr/README.md
+++ b/cmd/skr/README.md
@@ -4,6 +4,8 @@ The ```skr``` tool instantiates a web server ( <http://localhost>:<port>) which 
 
 The tool can be executed using the script [skr.sh](https://github.com/Microsoft/confidential-sidecar-containers/blob/main//docker/skr/skr.sh). If the port number is not specified, the port will default to 8080. This script take the environment variables `SkrSideCarArgs`, `Port`, `LogFile`, and `LogLevel` and passes them into `/bin/skr` with their corresponding flags.
 
+To use the GRPC server instead of the HTTP server, the tool can be executed using the same script [skr.sh](https://github.com/Microsoft/confidential-sidecar-containers/blob/main//docker/skr/skr.sh). But instead expecting the environment variables `Port`, `ServerType`, `LogFile`, and `LogLevel` and passes them into `/bin/skr` with their corresponding flags.
+
 ## HTTP API
 
 The `status` GET method returns the status of the server. The response carries a `StatusOK` header and a payload of the following format:

--- a/docker/skr/skr-debug.sh
+++ b/docker/skr/skr-debug.sh
@@ -39,6 +39,10 @@ if [ -n "${LogLevel}" ]; then
   CmdlineArgs="${CmdlineArgs} -loglevel ${LogLevel}"
 fi
 
+if [ -n "${ServerType}" ]; then
+  CmdlineArgs="${CmdlineArgs} -server_type ${ServerType}"
+fi
+
 echo CmdlineArgs = $CmdlineArgs
 
 if /bin/skr $CmdlineArgs; then

--- a/docker/skr/skr.sh
+++ b/docker/skr/skr.sh
@@ -36,6 +36,10 @@ if [ -n "${LogLevel}" ]; then
   CmdlineArgs="${CmdlineArgs} -loglevel ${LogLevel}"
 fi
 
+if [ -n "${ServerType}" ]; then
+  CmdlineArgs="${CmdlineArgs} -server_type ${ServerType}"
+fi
+
 echo CmdlineArgs = $CmdlineArgs
 
 if /bin/skr $CmdlineArgs; then

--- a/examples/skr/aks/README.md
+++ b/examples/skr/aks/README.md
@@ -160,8 +160,10 @@ Push the container images to your container registry.
 
 ### 7. Running the SKR Container in a TEE
 
-Use the SKR container as a GRPC service during runtime to unwrap the secret with the private key stored in mHSM.
+Use the SKR container as a gRPC service during runtime to unwrap the secret with the private key stored in mHSM.
 This step ensures that the private key is securely retrieved in the SKR container and used for unwrapping the wrapped secret.
+Note that gRPC is off by default and the environment variable `ServerType` can be set to `grpc` to enable the gRPC server and disable the HTTP server.
+An example `Port` value for gRPC is `50000`.
 
 You can run an example deployment of a confidential pod with the `SKR` container and a `example-unwrap` container that invokes the secret provisioning APIs of the `SKR` container. Use the [example pod yaml file](skr-example-template.yaml) to deploy the pod. First, create an image pull secret (this example uses an Azure Container Registry) then deploy the pod with kubectl using the following command:
 

--- a/examples/skr/aks/skr-example-template.yaml
+++ b/examples/skr/aks/skr-example-template.yaml
@@ -11,13 +11,17 @@ spec:
   - image: $SKR_IMAGE
     imagePullPolicy: Always
     name: skr
-    command: 
+    command:
     - /skr.sh
     env:
     - name: SkrSideCarArgs
       value: ewogICAgImNlcnRjYWNoZSI6IHsKCQkiZW5kcG9pbnRfdHlwZSI6ICJMb2NhbFRISU0iLAoJCSJlbmRwb2ludCI6ICIxNjkuMjU0LjE2OS4yNTQvbWV0YWRhdGEvVEhJTS9hbWQvY2VydGlmaWNhdGlvbiIKCX0gIAp9
     - name: UVM_SECURITY_CONTEXT_DIR
       value: /opt/confidential-containers/share/kata-containers
+    - name: Port
+      value: "50000"
+    - name: ServerType
+      value: "grpc"
     volumeMounts:
     - mountPath: /opt/confidential-containers/share/kata-containers/reference-info-base64
       name: endorsement-location


### PR DESCRIPTION
Having the gRPC server on by default on port 50000 might interfere with customer servers, so we should turn it off by default and enable it by setting the KEYPROVIDER_SOCK environment variable.

This was tested in the ACI and AKS pipelines manually and will make respective PRs once there is an official build. Thanks!