### PR TITLE
make repository dispatch call to run aci-examples tests

### DIFF
--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -1,0 +1,19 @@
+name: Create Pull Request Comment
+
+on:
+  repository_dispatch:
+    types: [pipeline-link-comment]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+                issue_number: ${{ github.event.client_payload.pr_number }},
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: 'Please ensure the following pipeline is passing: ${{ github.event.client_payload.pipeline_link }}'
+            })

--- a/.github/workflows/push_attestation_image.yml
+++ b/.github/workflows/push_attestation_image.yml
@@ -62,3 +62,15 @@ jobs:
           push: true
           tags: |
             ${{ secrets.REGISTRY_NAME }}.${{ secrets.REGISTRY_DOMAIN }}/attestation:${{ steps.get_image_tag.outputs.image_tag }}
+
+      - name: Run Attestation Tests
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          curl --fail-with-body -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.ACC_REPO_DISPATCH_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/microsoft/confidential-aci-examples/dispatches \
+          -d '{"event_type":"attestation-test","client_payload":{"image_tag":"${{ steps.get_image_tag.outputs.image_tag }}","pr_number":"${{ github.event.number }}"}}'

--- a/.github/workflows/push_encfs_image.yml
+++ b/.github/workflows/push_encfs_image.yml
@@ -46,7 +46,8 @@ jobs:
       - name: Build Image
         run: docker/encfs/build.sh
 
-      - name: Push Image
+      - name: Get Image Tag
+        id: get_image_tag
         run: |
           if [ ${{ github.event_name }} == "push" ]; then
             branch_name=main
@@ -57,8 +58,24 @@ jobs:
             branch_name=${{ github.head_ref }}
           fi
           image_tag=$(echo ${branch_name:0:128} | sed 's/[^a-zA-Z0-9]/-/g')
+          echo "image_tag=$(echo $image_tag)" >> $GITHUB_OUTPUT
+
+      - name: Push Image
+        run: |
           docker/encfs/push.sh \
             ${{ secrets.REGISTRY_NAME }} \
             ${{ secrets.REGISTRY_DOMAIN }} \
-            encfs:$image_tag \
+            encfs:${{ steps.get_image_tag.outputs.image_tag }} \
             --skip-login
+
+      - name: Run ENCFS Tests
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          curl --fail-with-body -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.ACC_REPO_DISPATCH_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/microsoft/confidential-aci-examples/dispatches \
+          -d '{"event_type":"encfs-test","client_payload":{"image_tag":"${{ steps.get_image_tag.outputs.image_tag }}","pr_number":"${{ env.PR_NUMBER }}"}}'

--- a/.github/workflows/push_skr_image.yml
+++ b/.github/workflows/push_skr_image.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Build Image
         run: docker/skr/build.sh
 
-      - name: Push Image
+      - name: Get Image Tag
+        id: get_image_tag
         run: |
           if [ ${{ github.event_name }} == "push" ]; then
             branch_name=main
@@ -56,8 +57,24 @@ jobs:
             branch_name=${{ github.head_ref }}
           fi
           image_tag=$(echo ${branch_name:0:128} | sed 's/[^a-zA-Z0-9]/-/g')
+          echo "image_tag=$(echo $image_tag)" >> $GITHUB_OUTPUT
+
+      - name: Push Image
+        run: |
           docker/skr/push.sh \
             ${{ secrets.REGISTRY_NAME }} \
             ${{ secrets.REGISTRY_DOMAIN }} \
-            skr:$image_tag \
+            skr:${{ steps.get_image_tag.outputs.image_tag }} \
             --skip-login
+
+      - name: Run SKR Tests
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          curl --fail-with-body -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.ACC_REPO_DISPATCH_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/microsoft/confidential-aci-examples/dispatches \
+          -d '{"event_type":"skr-test","client_payload":{"image_tag":"${{ steps.get_image_tag.outputs.image_tag }}","pr_number":"${{ github.event.number }}"}}'


### PR DESCRIPTION
Make repository dispatch call to aci-examples repo to run tests for sidecars automatically.

Review in conjunction with: https://github.com/microsoft/confidential-aci-examples/pull/116