### PR TITLE
Fixing SKR logging flags in SKR shell scripts

### DIFF
--- a/docker/skr/skr-debug.sh
+++ b/docker/skr/skr-debug.sh
@@ -32,11 +32,11 @@ fi
 
 # LogFile and LogLevel are expected to be passed in as environment variables
 if [ -n "${LogFile}" ]; then
-  CmdlineArgs="${CmdlineArgs} -logFile ${LogFile}"
+  CmdlineArgs="${CmdlineArgs} -logfile ${LogFile}"
 fi
 
 if [ -n "${LogLevel}" ]; then
-  CmdlineArgs="${CmdlineArgs} -logLevel ${LogLevel}"
+  CmdlineArgs="${CmdlineArgs} -loglevel ${LogLevel}"
 fi
 
 echo CmdlineArgs = $CmdlineArgs

--- a/docker/skr/tests/skr_test.sh
+++ b/docker/skr/tests/skr_test.sh
@@ -39,11 +39,11 @@ fi
 
 # LogFile and LogLevel are expected to be passed in as environment variables
 if [ -n "${LogFile}" ]; then
-  CmdlineArgs="${CmdlineArgs} -logFile ${LogFile}"
+  CmdlineArgs="${CmdlineArgs} -logfile ${LogFile}"
 fi
 
 if [ -n "${LogLevel}" ]; then
-  CmdlineArgs="${CmdlineArgs} -port ${LogLevel}"
+  CmdlineArgs="${CmdlineArgs} -loglevel ${LogLevel}"
 fi
 
 echo CmdlineArgs = $CmdlineArgs


### PR DESCRIPTION
A [previous PR](https://github.com/microsoft/confidential-sidecar-containers/pull/53) addressed a mismatch in flag names between `docker/skr/skr.sh` and `cmd/skr/main.go`, particularly concerning the `-logfile` and `-loglevel` flags. This mismatch prevented users from successfully running the SKR container when logging parameters were specified in their ARM templates.

**This PR** extends the fix to the remaining SKR shell scripts. The following changes were made:
1. In `docker/skr/skr-debug.sh`, replaced `-logFile ${LogFile}` with `-logfile ${LogFile}` and `-logLevel ${LogLevel}` with `-loglevel ${LogLevel}`.
2. In `docker/skr/skr_test.sh`, replaced `-logFile ${LogFile}` with `-logfile ${LogFile}` and corrected `-port ${LogLevel}` to `-loglevel ${LogLevel}`.