### PR TITLE
remove aasp references

### DIFF
--- a/examples/skr/aks/unwrap.sh
+++ b/examples/skr/aks/unwrap.sh
@@ -20,7 +20,7 @@ if [ -z "${KEY_PROVIDER_PORT}" ]; then
   KEY_PROVIDER_PORT=50000
 fi
 
-AAA=`printf aasp | base64 -w0`
+AAA=`printf skr | base64 -w0`
 ANNO=`cat ${infile}`
 REQ=`echo "{\"op\":\"keyunwrap\",\"keywrapparams\":{},\"keyunwrapparams\":{\"dc\":{\"Parameters\":{\"attestation-agent\":[\"${AAA}\"]}},\"annotation\":\"${ANNO}\"}}" | base64 -w0`
 echo KeyProviderKeyWrapProtocolInput: ${REQ}

--- a/pkg/grpc/grpcserver/server.go
+++ b/pkg/grpc/grpcserver/server.go
@@ -49,7 +49,7 @@ type AzureInformation struct {
 }
 
 const (
-	AASP = "aasp"
+	SKR = "skr"
 )
 
 type DecryptConfig struct {
@@ -186,7 +186,7 @@ func (s *Server) WrapKey(c context.Context, grpcInput *keyprovider.KeyProviderKe
 
 	aa := tokens[0]
 	kid := tokens[1]
-	if !strings.EqualFold(aa, AASP) {
+	if !strings.EqualFold(aa, SKR) {
 		return nil, status.Errorf(codes.InvalidArgument, "Unexpected attestation agent %v specified. Perhaps you send the request to a wrong endpoint?", aa)
 	}
 	log.Printf("Attestation agent: %v, kid: %v", aa, kid)
@@ -226,7 +226,7 @@ func (s *Server) UnWrapKey(c context.Context, grpcInput *keyprovider.KeyProvider
 	aa, _ := base64.StdEncoding.DecodeString(dc.Parameters["attestation-agent"][0])
 	log.Printf("Attestation agent name: %v", string(aa))
 
-	if !strings.EqualFold(string(aa), AASP) {
+	if !strings.EqualFold(string(aa), SKR) {
 		return nil, status.Errorf(codes.InvalidArgument, "Unexpected attestation agent %v specified. Perhaps you send the request to a wrong endpoint?", string(aa))
 	}
 


### PR DESCRIPTION
Remove remaining AASP references to be consistent in naming throughout

Pipelines:
ENCFS: https://github.com/microsoft/confidential-aci-examples/actions/runs/7463714326
SKR: https://github.com/microsoft/confidential-aci-examples/actions/runs/7463717634