### PR TITLE
ignore main tag in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main
-    tags:        
-      - '*'
+    tags-ignore:        
+      - 'main'
     paths:
       - .github/workflows/release.yml
       - tools/get-snp-report/**


### PR DESCRIPTION
Tags with the name "main" are generated on the main branch that cause a release with the name "main" to be created through the release pipeline. By using tags-ignore, we should bypass this and just create releases with the numerical tags we've been using.