### PR TITLE
update skr to use cbl mariner

### DIFF
--- a/docker/skr/Dockerfile.skr
+++ b/docker/skr/Dockerfile.skr
@@ -6,9 +6,9 @@ RUN cd tools/get-snp-report && make && mv bin/get-snp-report / && mv bin/get-fak
 
 RUN cd cmd/skr && CGO_ENABLED=0 GOOS=linux go build -o /skr -ldflags="-s -w" main.go
 
-FROM alpine:3.18.6
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
-RUN apk update && apk upgrade --no-cache && apk add --no-cache curl
+RUN tdnf update -y && tdnf upgrade -y && tdnf install curl
 
 COPY --from=build /skr /get-snp-report /get-fake-snp-report ./bin/
 


### PR DESCRIPTION
Update SKR to use CBL Mariner image as a base. Resolves issue #109 

Passing pipeline: https://github.com/microsoft/confidential-aci-examples/actions/runs/8511872960