### PR TITLE
converting debug and example image to mariner

### DIFF
--- a/buildall.sh
+++ b/buildall.sh
@@ -22,6 +22,8 @@ pushd tools/get-snp-report
 make
 popd
 cp tools/get-snp-report/bin/get-snp-report ./bin
+# verbose-report is used in the skr debug image
+cp tools/get-snp-report/bin/verbose-report ./bin
 cp tools/get-snp-report/bin/get-fake-snp-report ./bin
 
 pushd docker/encfs

--- a/docker/skr/Dockerfile.debug
+++ b/docker/skr/Dockerfile.debug
@@ -1,6 +1,6 @@
-FROM ubuntu:18.04
-RUN apt update
-RUN apt install --fix-missing -y net-tools wget curl bc jq bash vim ssh
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+
+RUN tdnf update -y && tdnf upgrade -y && tdnf install wget curl jq tar ca-certificates vim openssh-server -y && tdnf clean all
 
 # clearly this is extremely insecure but is only for debugging
 # do not copy this.
@@ -14,7 +14,7 @@ RUN mkdir /run/sshd
 # which can be used to trick an attestation agent or relying party
 
 COPY ./bin/skr ./bin/get-snp-report ./bin/verbose-report /bin/
-COPY skr.sh skr-debug.sh tests/*_client.sh tests/skr_test.sh /
+COPY ./docker/skr/skr.sh ./docker/skr/skr-debug.sh ./docker/skr/tests/*_client.sh ./docker/skr/tests/skr_test.sh /
 RUN mkdir -p /tests/skr; mv *_client.sh /tests/skr; mv skr_test.sh /tests/skr
 RUN chmod +x /*.sh /tests/skr/*.sh; date > /made-date
 

--- a/docker/skr/Dockerfile.example
+++ b/docker/skr/Dockerfile.example
@@ -1,6 +1,6 @@
-FROM alpine:3.18.6
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 
-RUN apk update && apk upgrade --no-cache && apk --no-cache add wget curl jq
+RUN tdnf update -y && tdnf upgrade -y && tdnf install wget curl jq tar ca-certificates -y && tdnf clean all
 
 COPY ./examples/skr/aks/unwrap.sh /bin/
 COPY ./examples/skr/aks/wrapped /

--- a/docker/skr/build-debug.sh
+++ b/docker/skr/build-debug.sh
@@ -8,20 +8,20 @@ pushd $(dirname $0)
 
 # This script builds the binaries and sets up the docker image
 
-mkdir -p bin
-pushd bin
+mkdir -p ../../bin
+pushd ../../bin
 CGO_ENABLED=0 GOOS=linux go build github.com/Microsoft/confidential-sidecar-containers/cmd/skr
 popd
 
 pushd ../../tools/get-snp-report
-make 
+make
 popd
 
-cp ../../tools/get-snp-report/bin/get-snp-report ./bin
-cp ../../tools/get-snp-report/bin/get-fake-snp-report ./bin
-cp ../../tools/get-snp-report/bin/verbose-report ./bin
+cp ../../tools/get-snp-report/bin/get-snp-report ../../bin/
+cp ../../tools/get-snp-report/bin/get-fake-snp-report ../../bin/
+cp ../../tools/get-snp-report/bin/verbose-report ../../bin/
 
-docker build --tag skr -f Dockerfile.debug .
+docker build --tag skr -f Dockerfile.debug ../..
 
 # cleanup
 rm -rf bin


### PR DESCRIPTION
These two dockerfiles were still using images hosted on docker hub. This PR converts them to use Mariner as well as simplifies the interface to build them.

As it is, the context needed for `Dockerfile.debug` needs to be `./docker/skr` while `Dockerfile.example` uses the root of the repo as its context. `Dockerfile.debug` now uses the root as well to simplify