### PR TITLE
remove trivy scan exit code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
         scan-ref: '.'
         format: 'sarif'
         output: 'trivy-results.sarif'
-        exit-code: 1
         severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
 
     - name: Upload Trivy scan results to GitHub Security tab


### PR DESCRIPTION
Remove Trivy Security Scan exit code so that the scan results get uploaded.