### PR TITLE
Separate cleanup and CI steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
     branches: [ "main" ]
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
   workflow_call:
     inputs:
       location:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 23 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Scheduled CI regularly fails where PR CI looks fine, I suspect the cleanup workflow is clashing such that things like keys and encfs's are cleaned up before using

Also allowing CI to be manually triggered