### PR TITLE
Temporarily add runner IP to storage allowlist

### DIFF
--- a/tests/encfs/test.py
+++ b/tests/encfs/test.py
@@ -66,7 +66,7 @@ class EncFSTest(unittest.TestCase):
             "network-rule", "add",
             "--resource-group", os.environ["RESOURCE_GROUP"],
             "--account-name", cls.storage_account_name,
-            "--ip-address", requests.get("https://ifconfig.me").text,
+            "--ip-address", "0.0.0.0/0",
         ], check=True)
 
         if not aci_is_live(**azure_args, name=id):
@@ -146,7 +146,7 @@ class EncFSTest(unittest.TestCase):
             "network-rule", "remove",
             "--resource-group", os.environ["RESOURCE_GROUP"],
             "--account-name", cls.storage_account_name,
-            "--ip-address", requests.get("https://ifconfig.me").text,
+            "--ip-address", "0.0.0.0/0",
         ], check=True)
 
     def test_read_rw_encfs(self):

--- a/tests/encfs/test.py
+++ b/tests/encfs/test.py
@@ -38,7 +38,7 @@ class EncFSTest(unittest.TestCase):
 
         attestation_endpoint = os.environ["ATTESTATION_ENDPOINT"]
         hsm_endpoint = os.environ["HSM_ENDPOINT"]
-        cls.storage_account_name = os.environ["cls.STORAGE_ACCOUNT_NAME"]
+        cls.storage_account_name = os.environ["STORAGE_ACCOUNT_NAME"]
         storage_container_name = os.environ["STORAGE_CONTAINER_NAME"]
         key_id = f"{id}-key"
         cls.test_file_content = "Hello, World!"

--- a/tests/encfs/test.py
+++ b/tests/encfs/test.py
@@ -119,7 +119,7 @@ class EncFSTest(unittest.TestCase):
             "network-rule", "add",
             "--resource-group", os.environ["RESOURCE_GROUP"],
             "--account-name", cls.storage_account_name,
-            "--ip-address", "0.0.0.0/0",
+            "--ip-address", "0.0.0.0/0"],
             check=True,
         )
 
@@ -146,7 +146,7 @@ class EncFSTest(unittest.TestCase):
             "network-rule", "remove",
             "--resource-group", os.environ["RESOURCE_GROUP"],
             "--account-name", cls.storage_account_name,
-            "--ip-address", "0.0.0.0/0",
+            "--ip-address", "0.0.0.0/0"],
             check=True,
         )
 

--- a/tests/encfs/test.py
+++ b/tests/encfs/test.py
@@ -61,6 +61,14 @@ class EncFSTest(unittest.TestCase):
             "tag": tag,
         }
 
+        subprocess.run([
+            "az", "storage", "account",
+            "network-rule", "add",
+            "--resource-group", os.environ["RESOURCE_GROUP"],
+            "--account-name", cls.storage_account_name,
+            "--ip-address", requests.get("https://ifconfig.me").text,
+        ], check=True)
+
         if not aci_is_live(**azure_args, name=id):
 
             aci_param_set(
@@ -115,14 +123,6 @@ class EncFSTest(unittest.TestCase):
                             "sudo", "cp", test_file.name, os.path.join(filesystem, "file.txt")
                         ], check=True)
 
-        subprocess.run([
-            "az", "storage", "account",
-            "network-rule", "add",
-            "--resource-group", os.environ["RESOURCE_GROUP"],
-            "--account-name", cls.storage_account_name,
-            "--ip-address", requests.get("https://ifconfig.me").text,
-        ], check=True)
-
         cls.aci_context = target_run_ctx(
             target=target_dir,
             name=id,
@@ -135,24 +135,6 @@ class EncFSTest(unittest.TestCase):
 
         cls.encfs_id, = cls.aci_context.__enter__()
         cls.encfs_ip = aci_get_ips(ids=cls.encfs_id)
-
-        subprocess.run([
-            "az", "storage", "account",
-            "network-rule", "add",
-            "--resource-group", os.environ["RESOURCE_GROUP"],
-            "--account-name", cls.storage_account_name,
-            "--ip-address", cls.encfs_ip
-        ], check=True)
-
-        time.sleep(10)
-
-        subprocess.run([
-            "az", "container", "restart",
-            "--resource-group", os.environ["RESOURCE_GROUP"],
-            "--name", id,
-        ], check=True)
-
-
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/encfs/test.py
+++ b/tests/encfs/test.py
@@ -119,7 +119,7 @@ class EncFSTest(unittest.TestCase):
             "network-rule", "add",
             "--resource-group", os.environ["RESOURCE_GROUP"],
             "--account-name", cls.storage_account_name,
-            "--ip-address", requests.get("https://ifconfig.me").text],
+            "--ip-address", "0.0.0.0/0",
             check=True,
         )
 
@@ -146,7 +146,7 @@ class EncFSTest(unittest.TestCase):
             "network-rule", "remove",
             "--resource-group", os.environ["RESOURCE_GROUP"],
             "--account-name", cls.storage_account_name,
-            "--ip-address", requests.get("https://ifconfig.me").text],
+            "--ip-address", "0.0.0.0/0",
             check=True,
         )
 


### PR DESCRIPTION
Temporarily addresses #130 

Not an ideal solution since we open up ip access temporarily, since adding specific IP addresses doesn't seem to work for ACI

If we can fix that, we should only add the rule for the specific IP addresses (runner and ACI)