### PR TITLE
Bump c-aci-testing version

### DIFF
--- a/scripts/install-c-aci-testing.sh
+++ b/scripts/install-c-aci-testing.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-gh release download 1.0.2 -R microsoft/confidential-aci-testing
+gh release download 1.0.3 -R microsoft/confidential-aci-testing
 python -m pip install c_aci_testing*.tar.gz
 rm c_aci_testing*.tar.gz


### PR DESCRIPTION
Bumping to move from docker-compose v1 to v2, v1 is intermittently failing in actions