### PR TITLE
Adding support for releasing ECDSA key type

### DIFF
--- a/pkg/skr/skr.go
+++ b/pkg/skr/skr.go
@@ -5,9 +5,11 @@ package skr
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"fmt"
 	"strings"
 
 	"github.com/Microsoft/confidential-sidecar-containers/pkg/attest"
@@ -138,7 +140,22 @@ func SecureKeyRelease(identity common.Identity, certState attest.CertState, SKRK
 			return nil, errors.Wrapf(err, "could not encode RSA key as JWK")
 		}
 		return jwKey, nil
+	} else if kty == "EC-HSM" || kty == "EC" {
+		key, err := x509.ParsePKCS8PrivateKey(keyBytes)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not parse ECDSA key")
+		}
+
+		var privateEcdsaKey *ecdsa.PrivateKey = key.(*ecdsa.PrivateKey)
+
+		jwKey := jwk.NewECDSAPrivateKey()
+		err = jwKey.FromRaw(privateEcdsaKey)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not encode ECDSA key as JWK")
+		}
+		return jwKey, nil
 	} else {
-		return nil, errors.Wrapf(err, "released key type not supported")
+		err = fmt.Errorf("released key type %v not supported", kty)
+		return nil, err
 	}
 }


### PR DESCRIPTION
We have a scenario to release EC key type and realized that the skr sidecar was not supporting this key type. Added support for the same.

Also when we tried before this change the code path in skr failed with a panic as the unsupported key type path was returning a nil error as error.wrapf() being invoked with a nil error returns a nil. Then the caller does not detect an error and proceeds to a nil ref. Fixed this path.

```sh
runtime error: invalid memory address or nil pointer dereference
/usr/local/go/src/runtime/panic.go:260 (0x44bf15)
/usr/local/go/src/runtime/signal_unix.go:839 (0x44bee5)
/go/src/github.com/microsoft/confidential-sidecar-containers/internal/httpginendpoints/httpginendpoints.go:232 (0xa620b4)
/go/src/github.com/microsoft/confidential-sidecar-containers/vendor/github.com/gin-gonic/gin/context.go:174 (0xa6290a)
/go/src/github.com/microsoft/confidential-sidecar-containers/internal/httpginendpoints/httpginendpoints.go:248 (0xa628ef)
/go/src/github.com/microsoft/confidential-sidecar-containers/vendor/github.com/gin-gonic/gin/context.go:174 (0xa57921)
/go/src/github.com/microsoft/confidential-sidecar-containers/vendor/github.com/gin-gonic/gin/recovery.go:102 (0xa5790c)
/go/src/github.com/microsoft/confidential-sidecar-containers/vendor/github.com/gin-gonic/gin/context.go:174 (0xa56a26)
/go/src/github.com/microsoft/confidential-sidecar-containers/vendor/github.com/gin-gonic/gin/logger.go:240 (0xa56a09)
/go/src/github.com/microsoft/confidential-sidecar-containers/vendor/github.com/gin-gonic/gin/context.go:174 (0xa55ab0)
/go/src/github.com/microsoft/confidential-sidecar-containers/vendor/github.com/gin-gonic/gin/gin.go:620 (0xa55718)
/go/src/github.com/microsoft/confidential-sidecar-containers/vendor/github.com/gin-gonic/gin/gin.go:576 (0xa5525c)
/usr/local/go/src/net/http/server.go:2947 (0x6dcbcb)
/usr/local/go/src/net/http/server.go:1991 (0x6d7de6)
/usr/local/go/src/runtime/asm_amd64.s:1594 (0x466920)```