### PR TITLE
 Fix broken Dockerfile links in AKS SKR README (#155)

### DIFF
--- a/examples/skr/aks/README.md
+++ b/examples/skr/aks/README.md
@@ -146,8 +146,8 @@ az identity federated-credential create --name ${FEDERATED_CREDENTIAL_IDENTITY_N
 
 In order to use grpcurl to call the exposed grpc APIs to unwrap secrets, users must build the following two images:
 
-1. The `SKR container` image that hosts grpc server. See [Dockerfile.build](../../docker/skr/Dockerfile.skr)
-2. A `example-unwrap` container image that has grpcurl installed and allows users to unwrap secrets. [Dockerfile.example](../../docker/skr/Dockerfile.example)
+1. The `SKR container` image that hosts grpc server. See [Dockerfile.build](../../../docker/skr/Dockerfile.skr)
+2. A `example-unwrap` container image that has grpcurl installed and allows users to unwrap secrets. [Dockerfile.example](../../../docker/skr/Dockerfile.example)
 
 To build the images, make sure you are in the root of confidential-sidecar-containers repo and run the following commands:
 


### PR DESCRIPTION
Resolves #155

This PR updates the relative paths to the Dockerfiles used in the AKS SKR documentation:
- Changed `Dockerfile.build` link from `../../docker/skr/Dockerfile.skr` to `../../../docker/skr/Dockerfile.skr`.
- Changed `Dockerfile.example` link from `../../docker/skr/Dockerfile.example` to `../../../docker/skr/Dockerfile.example`.

These fixes address the invalid hyperlinks and ensure the README points to the correct Dockerfiles.
