### PR TITLE
update release to run on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Create Release
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 permissions:
   id-token: write
@@ -18,7 +18,6 @@ jobs:
   build:
     name: Build Binaries
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -56,7 +55,6 @@ jobs:
   create_release:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Github doesn't consider pushing tags to a branch to count so we have to specify pipeline runs to happen on tag pushes