### PR TITLE
Fix importkey README example, and give more useful error messages on config parse fail

### DIFF
--- a/tools/importkey/README.MD
+++ b/tools/importkey/README.MD
@@ -27,18 +27,20 @@ When importing a key to the key vault, a release policy is coupled with the key.
         "label": "Model Encryption Key"
     },
     "claims":[
-        {
-            "claim":  "x-ms-sevsnpvm-hostdata",
-            "equals": "99e1abd344fc0989288c44fde8de3b2a248b1b95814df8955d0c305a7db46680"
-        },
-        {
-            "claim": "x-ms-compliance-status",
-            "equals": "azure-compliant-uvm"
-        },
-        {
-            "claim": "x-ms-sevsnpvm-is-debuggable",
-            "equals": "false"
-        }
+        [
+            {
+                "claim":  "x-ms-sevsnpvm-hostdata",
+                "equals": "99e1abd344fc0989288c44fde8de3b2a248b1b95814df8955d0c305a7db46680"
+            },
+            {
+                "claim": "x-ms-compliance-status",
+                "equals": "azure-compliant-uvm"
+            },
+            {
+                "claim": "x-ms-sevsnpvm-is-debuggable",
+                "equals": "false"
+            }
+        ]
     ]
 }
 ```

--- a/tools/importkey/main.go
+++ b/tools/importkey/main.go
@@ -79,7 +79,7 @@ func main() {
 		fmt.Println("Error reading Azure services configuration")
 		os.Exit(1)
 	} else if err = json.Unmarshal(configBytes, importKeyCfg); err != nil {
-		fmt.Println("Error unmarshalling import key configuration " + string(configBytes))
+		fmt.Println("Error unmarshalling import key configuration: " + err.Error() + "\n" + string(configBytes))
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
README contains an example which doesn't work because importkey requires claims to be an array of array