### PR TITLE
update token endpoint per msal library update

### DIFF
--- a/pkg/msi/msi.go
+++ b/pkg/msi/msi.go
@@ -36,7 +36,7 @@ func GetAccessTokenFromFederatedToken(ctx context.Context, encodedResourceUrl st
 		return string(token), err
 	})
 
-	confidentialClient, err := confidential.New(fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/token", tenantID), clientID, cred)
+	confidentialClient, err := confidential.New(fmt.Sprintf("https://login.microsoftonline.com/%s", tenantID), clientID, cred)
 	if err != nil {
 		return "", fmt.Errorf("failed to create confidential client: %v", err)
 	}


### PR DESCRIPTION
update token endpoint from https://login.microsoftonline.com/%s/oauth2/token to https://login.microsoftonline.com/%s per msal library update

Updated example: https://github.com/AzureAD/microsoft-authentication-library-for-go/blob/b4b8bfc9569042572ccb82b648ea509075fadb74/README.md?plain=1#L51

