### PR TITLE
Combined endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The code in this repository should be located at ``$GOPATH/src/microsoft/confide
 [![CI](https://github.com/microsoft/confidential-sidecar-containers/actions/workflows/ci.yml/badge.svg?branch=main&event=schedule)](https://github.com/microsoft/confidential-sidecar-containers/actions/workflows/ci.yml)
 
 Each sidecar is tested under `./tests/<sidecar_name>`.
-Each directory is tested with [confidential-aci-testing](https://github.com/microsoft/confidential-aci-testing), and therefore contains:
+Each directory is tested with [confidential-aci-testing](https://github.com/microsoft/confidential-aci-testing) currently using version 1.0.6, and therefore contains:
 
 - A `docker-compose` file which describes the images to build.
 These typically include a primary container image which uses the sidecar.
@@ -21,6 +21,9 @@ There are also supplementary files which aid the deployment:
 - `deployments/` contains bicep templates and for long lived resources used by the tests, they are run once.
 - `cacitesting.env` describes the deployment conditions such as which subscription and resource group to deploy to.
 All required properties are populated, any unset values are optional/have default values.
+Source (ie ```. ./cacitesting.env```) this file and then invoke the c-aci-testing cli to run tests.
+This example leaves the deployed C-ACI container group running so it can be manually inspected via the Azure portal:
+```c-aci-testing target run tests/skr --deployment-name combined-monday --no-cleanup --policy-type "allow_all"```
 
 ## Secure key release (SKR) sidecar
 

--- a/cmd/skr/README.md
+++ b/cmd/skr/README.md
@@ -24,7 +24,7 @@ The response carries a `StatusOK` header and a payload of the following format:
 }
 ```
 
-The `attest/raw` POST method expects a JSON of the following format:
+The `attest/raw` and `attest/combined` POST methods expect JSON of the following format:
 
 ```json
 {
@@ -43,8 +43,18 @@ Upon success, the `attest/raw` POST method response carries a `StatusOK` header 
     "report": "<hex format of raw hardware attestation report>"
 }
 ```
+The `attest/combined` response payload contains all the fields required to support a full key release.
 
-Upon error, the `attest/raw` POST method response carries a `BadRequest` or `StatusForbidden` header and a payload of the following format:
+```json
+{
+	"endorsed_tcb": "64 bit hex encoded TCB field",
+	"endorsements": "base64 encoded certificate chain",
+	"evidence": "base64 encoded attestation report",
+	"uvm_endorsements": "base64 encoded uvm reference info COSESign1 document",
+}
+```
+
+Upon error, the `attest/raw` and `attest/combined` POST methods response carry a `BadRequest` or `StatusForbidden` header and a payload of the following format:
 
 ```json
 {

--- a/cmd/skr/main.go
+++ b/cmd/skr/main.go
@@ -202,6 +202,7 @@ func setupServer(certState *attest.CertState, identity *common.Identity, uvmInfo
 	server.Use(httpginendpoints.RegisterGlobalStates(certState, identity, uvmInfo))
 	server.GET("/status", httpginendpoints.GetStatus)
 	server.POST("/attest/raw", httpginendpoints.PostRawAttest)
+	server.POST("/attest/combined", httpginendpoints.PostCombinedAttest) // fetches uvm reference info, certs and attestation report in a form suitable for the Ad Selection API KMS
 	server.POST("/attest/maa", httpginendpoints.PostMAAAttest)
 	server.POST("/key/release", httpginendpoints.PostKeyRelease)
 	httpginendpoints.SetServerReady()

--- a/docker/skr/tests/attest_client.sh
+++ b/docker/skr/tests/attest_client.sh
@@ -9,6 +9,7 @@ if [ -z "${AttestClientRuntimeData}" ]; then
   AttestClientRuntimeData=$1  
 fi
 
+
 echo AttestClientRuntimeData = $AttestClientRuntimeData
 
 if [ -z "${AttestClientMAAEndpoint}" ]; then
@@ -20,8 +21,11 @@ echo AttestClientMAAEndpoint = $AttestClientMAAEndpoint
 while true; do
   if [ -z "${AttestClientMAAEndpoint}" ]; then
     curl -X POST -H 'Content-Type: application/json' -d "{\"runtime_data\": \"$AttestClientRuntimeData\"}" http://localhost:8080/attest/raw > /raw.out;  
+    curl -X POST -H 'Content-Type: application/json' -d "{\"runtime_data\": \"$AttestClientRuntimeData\"}" http://localhost:8080/attest/combined > /combined.out;  
   else
     curl -X POST -H 'Content-Type: application/json' -d "{\"maa_endpoint\": \"$AttestClientMAAEndpoint\", \"runtime_data\": \"$AttestClientRuntimeData\"}" http://localhost:8080/attest/maa > /maatoken.out; 
   fi
   sleep 5;
+  ls -l *.out
 done
+ls -l *.

--- a/internal/httpginendpoints/httpginendpoints.go
+++ b/internal/httpginendpoints/httpginendpoints.go
@@ -85,6 +85,7 @@ func PostRawAttest(c *gin.Context) {
 	inittimeDataBytes, err := base64.StdEncoding.DecodeString(uvmInfo.EncodedSecurityPolicy)
 
 	if err != nil {
+		// TODO: review this StatusForbidden - surely should be StatusInternalServerError
 		c.JSON(http.StatusForbidden, gin.H{"error": errors.Wrapf(err, "decoding policy from Base64 format failed\n%s", skr.ERROR_STRING).Error()})
 		return
 	}
@@ -98,24 +99,127 @@ func PostRawAttest(c *gin.Context) {
 
 	var attestationReportFetcher attest.AttestationReportFetcher
 	if attest.IsSNPVM() {
-
 		attestationReportFetcher, err = attest.NewAttestationReportFetcher()
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": errors.Wrapf(err, "failure to create attestationReportFetcher\n%s", skr.ERROR_STRING).Error()})
 		}
 	} else {
 		// Use dummy report if SEV device is not available
+		logrus.Debug("UnsafeNewFakeAttestationReportFetcher...")
 		hostData := attest.GenerateMAAHostData(inittimeDataBytes)
 		attestationReportFetcher = attest.UnsafeNewFakeAttestationReportFetcher(hostData)
 	}
 
 	reportData := attest.GenerateMAAReportData(runtimeDataBytes)
 	rawReport, err := attestationReportFetcher.FetchAttestationReportHex(reportData)
+	// TODO: review this StatusForbidden - surely should be StatusInternalServerError
 	if err != nil {
 		c.JSON(http.StatusForbidden, gin.H{"error": errors.Wrapf(err, "failure to fetch attestation report hex\n%s", skr.ERROR_STRING).Error()})
 	}
 
 	c.JSON(http.StatusOK, gin.H{"report": rawReport})
+}
+
+/*
+	As PostRawAttest but also the various certificates and the UVM reference info so as to suit the Privacy Sandbox.
+
+	see https://github.com/microsoft/azure-privacy-sandbox-kms/blob/main/test/attestation-samples/snp.json
+	{
+	    "endorsed_tcb": "0300000000000873",
+	    "endorsements": "base64 encoded certificate chain",
+	    "evidence": "base64 encoded attestation report",
+	    "uvm_endorsements": "base64 encoded uvm reference info COSESign1 document",
+	}
+
+	This is mostly easily obtainable from /security-context-* but this endpoint is provided for convenience.
+	It may also choose to do a better job of fetching the AMD certs, e.g. other sources than the local THIM and
+	with better retries.
+*/
+
+/*
+	Notice that the serialised names in CombinedAttestationData must follow the c++ code in the Privacy Sandbox dataplane shared
+	library. The member names must start with a capital due to the public/private convention in golang or the
+	value will not be emitted in the JSON.
+*/
+
+type CombinedAttestationData struct {
+	// PSP TCB version
+	EndorsedTcb string `json:"endorsed_tcb"`
+	// AMD certificate chain matching the attestation report
+	Endorsements string `json:"endorsements"`
+	// attestation report base64 encoded (note that this is different to the raw endpoint which returns it hex encoded)
+	Evidence string `json:"evidence"`
+	// In the absence of managed identity assignment to the container group
+	// an AAD token issued for authentication with AKV resource may be included
+	// in the request to release the key.
+	UvmEndorsements string `json:"uvm_endorsements"`
+}
+
+func PostCombinedAttest(c *gin.Context) {
+	var attestData RawAttestData
+
+	logrus.Debug("PostCombinedAttest...")
+	// Call BindJSON to bind the received JSON to AttestData
+	if err := c.ShouldBindJSON(&attestData); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": errors.Wrapf(err, "invalid request format\n%s", skr.ERROR_STRING).Error()})
+		return
+	}
+
+	uvmInfo, ok := c.MustGet("uvmInfo").(*common.UvmInformation)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": errors.New("uvmInfo is not set\n" + skr.ERROR_STRING)})
+		return
+	}
+
+	// base64 decode the incoming encoded security policy
+	inittimeDataBytes, err := base64.StdEncoding.DecodeString(uvmInfo.EncodedSecurityPolicy)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": errors.Wrapf(err, "decoding policy from Base64 format failed\n%s", skr.ERROR_STRING).Error()})
+		return
+	}
+
+	// standard base64 decode the incoming runtime data
+	runtimeDataBytes, err := base64.StdEncoding.DecodeString(attestData.RuntimeData)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": errors.Wrapf(err, "decoding base64-encoded runtime data of request failed\n%s", skr.ERROR_STRING).Error()})
+		return
+	}
+
+	var attestationReportFetcher attest.AttestationReportFetcher
+	if attest.IsSNPVM() {
+		attestationReportFetcher, err = attest.NewAttestationReportFetcher()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": errors.Wrapf(err, "failure to create attestationReportFetcher\n%s", skr.ERROR_STRING).Error()})
+			return
+		}
+	} else {
+		// Use dummy report if SEV device is not available
+		logrus.Debug("UnsafeNewFakeAttestationReportFetcher...")
+		hostData := attest.GenerateMAAHostData(inittimeDataBytes)
+		attestationReportFetcher = attest.UnsafeNewFakeAttestationReportFetcher(hostData)
+	}
+
+	reportData := attest.GenerateMAAReportData(runtimeDataBytes)
+	rawReport, err := attestationReportFetcher.FetchAttestationReportByte(reportData)
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": errors.Wrapf(err, "failure to fetch attestation report bytes\n%s", skr.ERROR_STRING).Error()})
+		return
+	}
+
+	certs := uvmInfo.InitialCerts
+	certsB64 := base64.StdEncoding.EncodeToString([]byte(certs.VcekCert + certs.CertificateChain))
+
+	combinedAttestationData := CombinedAttestationData{
+		EndorsedTcb:     certs.Tcbm,
+		Endorsements:    certsB64,
+		Evidence:        base64.StdEncoding.EncodeToString(rawReport),
+		UvmEndorsements: uvmInfo.EncodedUvmReferenceInfo,
+	}
+
+	// c.JSON will encode the CombinedAttestationData struct to JSON
+	c.JSON(http.StatusOK, combinedAttestationData)
 }
 
 // PostMAAAttest retrieves an attestation token issued by Microsoft Azure Attestation

--- a/pkg/attest/platform_cert_fetcher.go
+++ b/pkg/attest/platform_cert_fetcher.go
@@ -140,7 +140,7 @@ func DefaultAMDMilanCertFetcherNew() CertFetcher {
 	return CertFetcher{
 		EndpointType: "AMD",
 		Endpoint:     "kdsintf.amd.com/vcek/v1",
-		TEEType:      "Milan",
+		TEEType:      "Milan", // TODO test for Genoa case.
 		APIVersion:   "",
 		ClientID:     "",
 	}
@@ -150,7 +150,7 @@ func DefaultAMDMilanCertFetcherNew() CertFetcher {
 func DefaultAzureCertFetcherNew() CertFetcher {
 	return CertFetcher{
 		EndpointType: "AzCache",
-		Endpoint:     "global.acccache.azure.net",
+		Endpoint:     "global.acccache.azure.net", // TODO use appropriate regional endpoint (until IMDS is available for this it will need to be passed in)
 		TEEType:      "SevSnpVM",
 		APIVersion:   "api-version=2020-10-15-preview",
 		ClientID:     "clientId=ConfidentialACI",


### PR DESCRIPTION
Adds a new endpoint to the SKR sidecar - "/attest/combined" which invokes httpginendpoints.PostCombinedAttest and fetches uvm reference info, certs and attestation report in a form suitable for the Ad Selection API KMS.

This is really a convenience to obtain all the parts required rather than just raw report and then having client code which understands how to fetch the various collateral from within the main workload container. In particular that avoids needing to understand issues of TCB updates or sources of certs other than the initial set - those can be abstracted away by the sidecar (some of that is future work).

In particular, some of the Ad Selection API/Privacy Sandbox workloads are not written in C++ against the dataplane shared library, but are Java. This PR avoids complication in those and similar workloads.