### PR TITLE
remove version from docker-compose.yml because it's obsolete

### DIFF
--- a/tests/attestation/docker-compose.yml
+++ b/tests/attestation/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 volumes:
   uds:
 services:

--- a/tests/encfs/docker-compose.yml
+++ b/tests/encfs/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   primary:
     image: $REGISTRY/encfs/primary:$TAG

--- a/tests/skr/docker-compose.yml
+++ b/tests/skr/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   proxy:
     image: $REGISTRY/skr/proxy:$TAG


### PR DESCRIPTION
remove version from docker-compose.yml because it's obsolete to remove warning from tests