### PR TITLE
fix newline characters being attached to links in error messages

### DIFF
--- a/cmd/remotefs/main.go
+++ b/cmd/remotefs/main.go
@@ -15,9 +15,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const ERROR_STRING = "ERROR: Please refer to the documentation for more information on how to use this sidecar.\n" +
-	"ACI: https://github.com/microsoft/confidential-sidecar-containers/blob/main/examples/encfs/README.md\n" +
-	"Troubleshooting: https://github.com/microsoft/confidential-sidecar-containers/blob/main/examples/encfs/TROUBLESHOOTING.md\n"
+const ERROR_STRING = `ERROR: Please refer to the documentation for more information on how to use this sidecar
+ACI: https://github.com/microsoft/confidential-sidecar-containers/blob/main/examples/encfs/README.md
+Troubleshooting: https://github.com/microsoft/confidential-sidecar-containers/blob/main/examples/encfs/TROUBLESHOOTING.md`
 
 type AzureInfo struct {
 	CertFetcher attest.CertFetcher `json:"certcache,omitempty"`

--- a/pkg/skr/skr.go
+++ b/pkg/skr/skr.go
@@ -22,10 +22,10 @@ import (
 const (
 	ResourceIdManagedHSM = "https%3A%2F%2Fmanagedhsm.azure.net"
 	ResourceIdVault      = "https%3A%2F%2Fvault.azure.net"
-	ERROR_STRING         = "ERROR: Please refer to the documentation for more information on how to use this sidecar.\n" +
-		"ACI: https://github.com/microsoft/confidential-sidecar-containers/blob/main/examples/skr/aci/README.md\n" +
-		"KATA: https://github.com/microsoft/confidential-sidecar-containers/blob/main/examples/skr/aks/README.md\n" +
-		"Troubleshooting: https://github.com/microsoft/confidential-sidecar-containers/blob/main/examples/skr/TROUBLESHOOTING.md\n"
+	ERROR_STRING         = `ERROR: Please refer to the documentation for more information on how to use this sidecar.
+ACI: https://github.com/microsoft/confidential-sidecar-containers/blob/main/examples/skr/aci/README.md
+KATA: https://github.com/microsoft/confidential-sidecar-containers/blob/main/examples/skr/aks/README.md
+Troubleshooting: https://github.com/microsoft/confidential-sidecar-containers/blob/main/examples/skr/TROUBLESHOOTING.md`
 )
 
 // SecureKeyRelease releases a key identified by the KID and AKV in the keyblob.


### PR DESCRIPTION
fix newline characters being attached to links in error messages

See current output in this pipeline run: https://github.com/microsoft/confidential-container-demos/actions/runs/14912259879/job/42070091999?pr=34