### PR TITLE
Use Azure CLI 2.72.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/universal:linux",
 	"features": {
 		"ghcr.io/devcontainers/features/azure-cli:1": {
-			"version": "2.61.0"
+			"version": "2.72.0"
 		},
 		"ghcr.io/devcontainers/features/common-utils:2": {},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Install Azure CLI
         env:
-          AZ_CLI_VERSION: 2.61.0
+          AZ_CLI_VERSION: 2.72.0
         run: ./scripts/install-az-cli.sh
 
       - name: Setup Docker
@@ -179,7 +179,7 @@ jobs:
 
       - name: Install Azure CLI
         env:
-          AZ_CLI_VERSION: 2.61.0
+          AZ_CLI_VERSION: 2.72.0
         run: ./scripts/install-az-cli.sh
 
       - name: Setup Docker
@@ -236,7 +236,7 @@ jobs:
 
       - name: Install Azure CLI
         env:
-          AZ_CLI_VERSION: 2.61.0
+          AZ_CLI_VERSION: 2.72.0
         run: ./scripts/install-az-cli.sh
 
       - name: Setup Docker

--- a/scripts/install-az-cli.sh
+++ b/scripts/install-az-cli.sh
@@ -14,4 +14,4 @@ Components: main
 Architectures: $(dpkg --print-architecture)
 Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
 
-sudo apt-get install --allow-downgrades azure-cli=${AZ_CLI_VERSION:-2.61.0}-1~${AZ_DIST}
+sudo apt-get install --allow-downgrades azure-cli=${AZ_CLI_VERSION:-2.72.0}-1~${AZ_DIST}


### PR DESCRIPTION
### Why 

We have been seeing CI failures on main such as https://github.com/microsoft/confidential-sidecar-containers/actions/runs/15150328244

The error is 
```
ERROR: Can't get attribute 'NormalizedResponse' on <module 'msal.throttled_http_client' from '/opt/az/lib/python3.11/site-packages/msal/throttled_http_client.py'>
```

Based on the issue https://github.com/Azure/azure-cli/issues/31419 it looks like it is fixed in later versions so bumping here