### PR TITLE
Add key ops value to key release return

### DIFF
--- a/tests/skr/key.py
+++ b/tests/skr/key.py
@@ -69,6 +69,7 @@ def deploy_key(
                     "kty": "oct-HSM",
                     "k": urlsafe_b64encode(binascii.unhexlify(key_data)).decode(),
                     "key_size": 256,
+                    "key_ops": ["encrypt", "decrypt", "wrapKey", "unwrapKey"],
                 },
                 "hsm": True,
                 "attributes": {

--- a/tests/skr/test.py
+++ b/tests/skr/test.py
@@ -234,6 +234,8 @@ class SkrTest(unittest.TestCase):
             )
             assert skr_response.status_code == 200, skr_response.content.decode()
             assert json.loads(json.loads(skr_response.content.decode())["key"])["k"] != ""
+            expected_key_ops = {"encrypt", "decrypt", "wrapKey", "unwrapKey"}
+            assert set(json.loads(json.loads(skr_response.content.decode())["key"])["key_ops"]) == expected_key_ops
         else:
             print("\nSkipping Key Release test as MAA/mHSM endpoints not provided.\n")
 


### PR DESCRIPTION
Add key ops value to key release return such that the output from the key_release endpoint should look like:
 b'{"key":"{\\"k\\":\\"<key_value>\\",\\"key_ops\\":[<string list of key ops>],\\"kty\\":\\"<key_type>\\"}"}'