### PR TITLE
add attributes file to have git treat .sh and .json files as binary

### DIFF
--- a/info/attributes
+++ b/info/attributes
@@ -1,0 +1,2 @@
+*.sh binary
+*.json binary


### PR DESCRIPTION
add attributes file to have git treat .sh and .json files as binary

https://git-scm.com/docs/gitattributes
https://git-scm.com/docs/gitattributes#_defining_macro_attributes