### PR TITLE
Set key ops for RSA keys

### DIFF
--- a/pkg/skr/skr.go
+++ b/pkg/skr/skr.go
@@ -142,9 +142,13 @@ func SecureKeyRelease(identity common.Identity, certState attest.CertState, SKRK
 
 		logrus.Trace("Encoding RSA key as JWK...")
 		jwKey := jwk.NewRSAPrivateKey()
-		err = jwKey.FromRaw(privateRSAKey)
-		if err != nil {
+		if err := jwKey.FromRaw(privateRSAKey); err != nil {
 			return nil, errors.Wrapf(err, "could not encode RSA key as JWK")
+		}
+		if len(keyOps) > 0 {
+			if err := jwKey.Set(jwk.KeyOpsKey, keyOps); err != nil {
+				return nil, errors.Wrapf(err, "setting key_ops on JWK failed")
+			}
 		}
 		return jwKey, nil
 	} else if kty == "EC-HSM" || kty == "EC" {


### PR DESCRIPTION
EC and OCT keys are covered in [PR 217](https://github.com/microsoft/confidential-sidecar-containers/pull/217) but forgot to cover RSA keys.