### PR TITLE
Change test endpoints for certFetcher per request from THIM

### DIFF
--- a/pkg/attest/attest_test.go
+++ b/pkg/attest/attest_test.go
@@ -89,7 +89,7 @@ func Test_MAA(t *testing.T) {
 
 	certFetcher := CertFetcher{
 		EndpointType: "AzCache",
-		Endpoint:     "americas.test.acccache.azure.net",
+		Endpoint:     "thimpft2.thim.azure-test.net",
 		TEEType:      "SevSnpVM",
 		APIVersion:   "api-version=2020-10-15-preview",
 		ClientID:     "clientId=ConfidentialSidecarContainersTest",
@@ -102,7 +102,7 @@ func Test_MAA(t *testing.T) {
 
 	ProductionCertCache := CertFetcher{
 		EndpointType: "AzCache",
-		Endpoint:     "americas.acccache.azure.net",
+		Endpoint:     "thimpft2.thim.azure-test.net",
 		TEEType:      "SevSnpVM",
 		APIVersion:   "api-version=2020-10-15-preview",
 		ClientID:     "clientId=ConfidentialSidecarContainersTest",

--- a/pkg/attest/platform_cert_fetcher_test.go
+++ b/pkg/attest/platform_cert_fetcher_test.go
@@ -22,7 +22,7 @@ func Test_CertFetcher(t *testing.T) {
 	}
 
 	ValidEndpointType := "AzCache"
-	ValidEndpoint := "americas.test.acccache.azure.net"
+	ValidEndpoint := "thimpft2.thim.azure-test.net"
 	ValidTEEType := "SevSnpVM"
 	ValidAPIVersion := "api-version=2021-07-22-preview"
 	ClientID := "clientId=ConfidentialSidecarContainersTest"


### PR DESCRIPTION
THIM is currently planning to deprecate americas.test.acccache.azure.net due to SFI issues.