### PR TITLE
Do not log access tokens and keys in debug mode

### DIFF
--- a/cmd/azmount/filemanager/azure.go
+++ b/cmd/azmount/filemanager/azure.go
@@ -61,7 +61,6 @@ func tokenRefresher(credential azblob.TokenCredential) (t time.Duration) {
 		logrus.Errorf("Error retrieving token: %s", err)
 		return 0
 	}
-	logrus.Debugf("Retrieved new token: %s", refreshToken.AccessToken)
 
 	// Duration expects nanosecond count
 	ExpiresInSeconds, err := strconv.ParseInt(refreshToken.ExpiresIn, 10, 64)
@@ -125,16 +124,14 @@ func AzureSetup(urlString string, urlPrivate bool, identity common.Identity) err
 						return errors.Wrapf(err, "Timeout of 60 seconds expired. Could not obtain token")
 					}
 				} else {
-					logrus.Debugf("Token obtained: %s", token.AccessToken)
 					accessToken = token.AccessToken
 					break
 				}
 			}
 		}
 		tokenCredential := azblob.NewTokenCredential(accessToken, tokenRefresherFunc)
-		logrus.Debugf("Token credential created: %s", tokenCredential.Token())
 		fm.blobURL = azblob.NewPageBlobURL(*u, azblob.NewPipeline(tokenCredential, azblob.PipelineOptions{}))
-		logrus.Debugf("Blob URL created: %s", fm.blobURL)
+		logrus.Debugf("Blob URL created.")
 	} else {
 		// we can use anonymous credentials to access public azure blob storage
 		logrus.Trace("Using anonymous credentials to access public azure blob storage...")

--- a/cmd/remotefs/azurefs.go
+++ b/cmd/remotefs/azurefs.go
@@ -266,7 +266,7 @@ func releaseRemoteFilesystemKey(tempDir string, keyDerivationBlob common.KeyDeri
 			return "", errors.Wrapf(err, "failed to derive oct key")
 		}
 
-		logrus.Debugf("Symmetric key %s (salt: %s label: %s)", hex.EncodeToString(octetKeyBytes), keyDerivationBlob.Salt, labelString)
+		logrus.Debugf("Symmetric key salt: %s label: %s", keyDerivationBlob.Salt, labelString)
 	default:
 		return "", errors.Wrapf(err, "key type %s not supported", jwKey.KeyType())
 	}

--- a/cmd/remotefs/main.go
+++ b/cmd/remotefs/main.go
@@ -120,8 +120,6 @@ func main() {
 		info.AzureFilesystems[i].KeyBlob.Authority.TEEType = "SevSnpVM"
 	}
 
-	logrus.Debugf("JSON = %+v", info)
-
 	err = MountAzureFilesystems(tempDir, info)
 	if err != nil {
 		logrus.Fatalf("Failed to mount filesystems: %s\n%s", err.Error(), ERROR_STRING)

--- a/pkg/common/keyblob.go
+++ b/pkg/common/keyblob.go
@@ -3,6 +3,8 @@
 
 package common
 
+import "fmt"
+
 // KeyDerivationBlob contains information about the key that needs to be derived
 // from a secret that has been released
 //
@@ -26,4 +28,12 @@ type KeyBlob struct {
 	KeyOps    []string `json:"key_ops,omitempty"`
 	Authority MAA      `json:"authority"`
 	AKV       AKV      `json:"akv"`
+}
+
+// Return a string representing this keyBlob without any AKV tokens
+func (kb KeyBlob) SafeString() string {
+	return fmt.Sprintf(
+		"keyBlob{ KID: %v, KTY: %v, KeyOps: %v, Authority: %+v, AKV: { Endpoint: %v, APIVersion: %v } }",
+		kb.KID, kb.KTY, kb.KeyOps, kb.Authority, kb.AKV.Endpoint, kb.AKV.APIVersion,
+	)
 }

--- a/pkg/common/maa.go
+++ b/pkg/common/maa.go
@@ -217,6 +217,6 @@ func (maa MAA) Attest(snpReportHexBytes []byte, vcekCertChain []byte, policyBlob
 		return "", errors.New("empty token string in maa response")
 	}
 
-	logrus.Debugf("MAA Token: %s", maaResponse.Token)
+	logrus.Debugf("MAA Token (signature redacted): %s", RedactMAAToken(maaResponse.Token))
 	return maaResponse.Token, nil
 }

--- a/pkg/common/token_test.go
+++ b/pkg/common/token_test.go
@@ -1,0 +1,20 @@
+package common
+
+import "testing"
+
+func Test_RedactMAAToken(t *testing.T) {
+	th := "e30."
+	testCases := [][2]string{
+		{th + "eyJpc3MiOiAiaHR0cHM6Ly9zaGFyZWRjbGMuY2xjLmF0dGVzdC5henVyZS5uZXQifQ.AAAA", th + "eyJpc3MiOiAiaHR0cHM6Ly9zaGFyZWRjbGMuY2xjLmF0dGVzdC5henVyZS5uZXQifQ.***"},
+		{"invalid", "<redacted invalid token: not a JWT>"},
+		{th + "eyJpc3MiOiAiaHR0cHM6Ly9zdHMubWljcm9zb2Z0LmNvbSJ9.AAAA", "<redacted token with issuer https://sts.microsoft.com>"},
+	}
+
+	for _, tc := range testCases {
+		input, expected := tc[0], tc[1]
+		actual := RedactMAAToken(input)
+		if actual != expected {
+			t.Errorf("Expected RedactToken(%q) to be %q, got %q", input, expected, actual)
+		}
+	}
+}

--- a/pkg/skr/skr.go
+++ b/pkg/skr/skr.go
@@ -116,7 +116,7 @@ func SecureKeyRelease(identity common.Identity, certState attest.CertState, skrK
 		return nil, errors.Wrapf(err, "releasing the key %s failed", skrKeyBlob.KID)
 	}
 
-	logrus.Debugf("Key Type: %s Key %v", kty, keyBytes)
+	logrus.Debugf("Successfully released key with type: %s", kty)
 
 	switch kty {
 	case "oct", "oct-HSM":

--- a/pkg/skr/skr.go
+++ b/pkg/skr/skr.go
@@ -105,7 +105,6 @@ func SecureKeyRelease(identity common.Identity, certState attest.CertState, skrK
 		// set the azure authentication token to the AKV instance
 		skrKeyBlob.AKV.BearerToken = bearerToken
 	}
-	logrus.Debugf("AAD Token: %s ", skrKeyBlob.AKV.BearerToken)
 
 	// use the MAA token obtained from the AKV's authority to retrieve the key identified by kid. The ReleaseKey
 	// operation requires the private wrapping key to unwrap the encrypted key material released from

--- a/pkg/skr/skr.go
+++ b/pkg/skr/skr.go
@@ -41,7 +41,7 @@ Troubleshooting: https://github.com/microsoft/confidential-sidecar-containers/bl
 // The return type is a JWK key
 func SecureKeyRelease(identity common.Identity, certState attest.CertState, skrKeyBlob common.KeyBlob, uvmInformation common.UvmInformation) (_ jwk.Key, err error) {
 	logrus.Info("Performing secure key release...")
-	logrus.Debugf("Releasing key blob: %v", skrKeyBlob)
+	logrus.Debugf("Releasing key blob: %s", skrKeyBlob.SafeString())
 
 	// Retrieve an MAA token
 	var maaToken string


### PR DESCRIPTION
We should not log sensitive materials regardless of the log level. Such logging is surprising and can end up leaking those information if the log is made available in unprotected places or turned on accidentally.  This PR redacts the tokens and removes some log calls with keys.

Example logs from skr:
```
level=info msg=Generating MAA Report Data...
level=info msg=Decoding UVM encoded security policy...
level=info msg=Running inside SNP VM, using real attestation report fetcher...
level=info msg=Generating MAA Report Data...
level=debug msg=   reportData: 5c467494b10092efeefe53f39b795c110e7d4e300a114baff0919c148af5eac90000000000000000000000000000000000000000000000000000000000000000
level=info msg=Fetching Attestation Report...
level=info msg=Deserializing Attestation Report...
level=debug msg=SNP Report Reported TCB: 15787368493747273732
Cert Chain TCBM Value: 15787368493747273732

level=info msg=Comparing TCB values...
level=info msg=TCB values match, using cached cert chain...
level=info msg=Retrieving MAA token...
level=info msg=Constructing MAA Attestation Request...
level=info msg=Marshalling MAA Endorsement...
level=debug msg=MAA Request: {"report":"eyJTbnBSZXBvcnQiOiJBd0FBQUFJQUFBQWZBQU1BQUFBQUFBRUFBQUFBQUFBQUFBQUFBQUFBQUFBQ0FBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBRUFBQUFFQUFBQUFBQVkyeVVBQUFBQUFBQUFBQUFBQUFBQUFBQmNSblNVc1FDUzctNy1VX09iZVZ3UkRuMU9NQW9SUzZfd2tad1VpdlhxeVFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFYLTdqRFcxLUdpb <snip...>

level=debug msg=Posting MAA Attestation Request to https://confidentialsidecars.weu.attest.azure.net/attest/SevSnpVM?api-version=2020-10-01
level=info msg=Unmarshalling MAA Attestation Response...
level=debug msg=MAA Token (signature redacted): eyJhbGciOiJSUzI1NiIsImprdSI6Imh0dHBzOi8vY29uZmlkZW50aWFsc2lkZWNhcnMud2V1LmF0dGVzdC5henVyZS5uZXQvY2VydHMiLCJraWQiOiJkUktoK2hCY1dVZlFpbVNsM0l2NlpoU3RXM1RTT3QwVGh3aVRnVVVxWkFvPSIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NTUyMTIwNzgsImlhdCI6MTc1NTE4MzI3OCwiaXNzIjoiaHR...<snip>...S4wIn0.***
```

Example logs from remotefs:
```
level=info msg=2 filesystems to mount:
level=info msg=  /mnt/remote/encfs-16970194319-1795--debug-blob1 -> https://cacisidecarsstorage.blob.core.windows.net/container/encfs-16970194319-1795--debug-blob1 (read-write: true)
level=debug msg=    keyBlob: keyBlob{ KID: encfs-16970194319-1795--debug-key, KTY: , KeyOps: [], Authority: {Endpoint:confidentialsidecars.weu.attest.azure.net TEEType: APIVersion:}, AKV: { Endpoint: cacisidecars.managedhsm.azure.net, APIVersion:  } }
level=debug msg=    KeyDerivationBlob: {Salt: Label:}
level=info msg=  /mnt/remote/encfs-16970194319-1795--debug-blob2 -> https://cacisidecarsstorage.blob.core.windows.net/container/encfs-16970194319-1795--debug-blob2 (read-write: false)
level=debug msg=    keyBlob: keyBlob{ KID: encfs-16970194319-1795--debug-key, KTY: , KeyOps: [], Authority: {Endpoint:confidentialsidecars.weu.attest.azure.net TEEType: APIVersion:}, AKV: { Endpoint: cacisidecars.managedhsm.azure.net, APIVersion:  } }
level=debug msg=    KeyDerivationBlob: {Salt: Label:}
```