### PR TITLE
Clean up encfs test container group

### DIFF
--- a/tests/encfs/test.py
+++ b/tests/encfs/test.py
@@ -147,7 +147,7 @@ class EncFSTest(unittest.TestCase):
             target_path=os.path.realpath(os.path.dirname(__file__)),
             deployment_name=id,
             tag=id,
-            cleanup=False,
+            cleanup=True,
             prefer_pull=True, # Images are built earlier, so don't rebuild
             **args_dict,
         )


### PR DESCRIPTION
Not sure if this is intentional, given that the skr test does clean it up?