### PR TITLE
Reduce repeated noise in debug level log

### DIFF
--- a/pkg/attest/attest.go
+++ b/pkg/attest/attest.go
@@ -6,6 +6,7 @@ package attest
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/Microsoft/confidential-sidecar-containers/pkg/common"
@@ -125,7 +126,8 @@ func (certState *CertState) getCollateral(maa common.MAA, runtimeDataBytes []byt
 	if err != nil {
 		return nil, nil, nil, nil, errors.Wrap(err, "Decoding policy from Base64 format failed")
 	}
-	logrus.Debugf("   inittimeDataBytes:    %v", inittimeDataBytes)
+	logrus.Tracef("   inittimeDataBytes:    %q", string(inittimeDataBytes))
+	logrus.Tracef("   runtimeDataBytes:   %q", string(runtimeDataBytes))
 
 	// Fetch the attestation report
 	var reportFetcher AttestationReportFetcher
@@ -143,6 +145,7 @@ func (certState *CertState) getCollateral(maa common.MAA, runtimeDataBytes []byt
 	}
 
 	reportData := GenerateMAAReportData(runtimeDataBytes)
+	logrus.Debugf("   reportData: %s", hex.EncodeToString(reportData[:]))
 	logrus.Info("Fetching Attestation Report...")
 	SNPReportBytes, err := reportFetcher.FetchAttestationReportByte(reportData)
 	if err != nil {

--- a/pkg/common/maa.go
+++ b/pkg/common/maa.go
@@ -67,7 +67,7 @@ func newAttestSNPRequestBody(snpAttestationReport []byte, vcekCertChain []byte, 
 	if len(uvmReferenceInfo) > 0 {
 		base64urlEncodedUvmReferenceInfo = base64.URLEncoding.EncodeToString(uvmReferenceInfo)
 	}
-	logrus.Debugf("base64urlEncodedUvmReferenceInfo: %s", base64urlEncodedUvmReferenceInfo)
+	logrus.Tracef("base64urlEncodedUvmReferenceInfo: %s", base64urlEncodedUvmReferenceInfo)
 
 	if GenerateTestData {
 		err = os.WriteFile("body.uvm_reference_info.bin", uvmReferenceInfo, 0644)
@@ -113,7 +113,9 @@ func newAttestSNPRequestBody(snpAttestationReport []byte, vcekCertChain []byte, 
 		Endorsements: base64urlEncodedmaaEndorsement,
 	}
 
-	logrus.Debugf("Marshalling maaReport: %+v", maaReport)
+	// We will eventually debug-log the maa request outside, so no need to be
+	// too verbose in the debug level log.
+	logrus.Tracef("Marshalling maaReport: %+v", maaReport)
 	maaReportJSONBytes, err := json.Marshal(maaReport)
 	if err != nil {
 		return nil, errors.Wrapf(err, "marhalling maa Report failed")
@@ -174,7 +176,7 @@ func (maa MAA) Attest(snpReportHexBytes []byte, vcekCertChain []byte, policyBlob
 		return "", errors.Wrapf(err, "creating new AttestSNPRequestBody failed")
 	}
 
-	logrus.Debugf("Marshalling MAA Attestation Request: %+v", request)
+	logrus.Tracef("Marshalling MAA Attestation Request: %+v", request)
 	maaRequestJSONData, err := json.Marshal(request)
 	if err != nil {
 		return "", errors.Wrapf(err, "marshalling maa request failed")


### PR DESCRIPTION
This changes some log messages related to MAA attest to trace level, since they are really long, and we will eventually log the full MAA request with debug level anyway, which would contains the same information.