### PR TITLE
GetToken: do retry

### DIFF
--- a/pkg/common/token.go
+++ b/pkg/common/token.go
@@ -8,8 +8,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 type Identity struct {
@@ -44,6 +46,27 @@ func GetToken(resourceId string, i Identity) (r TokenResponse, err error) {
 	}
 
 	uri := TokenURITemplate + resource_param + client_id_param
+
+	tries := 0
+	for {
+		r, err = _getToken(uri)
+		if err == nil {
+			return r, nil
+		}
+		tries++
+		logrus.Errorf("GetToken: attempt %d failed: %v", tries, err)
+		if tries < 3 {
+			delay := time.Second * time.Duration(tries*tries)
+			logrus.Debugf("Retrying after %ds", delay/time.Second)
+			time.Sleep(delay)
+		} else {
+			logrus.Errorf("GetToken failed after %d attempts", tries)
+			return r, err
+		}
+	}
+}
+
+func _getToken(uri string) (r TokenResponse, err error) {
 	httpResponse, err := HTTPGetRequest(uri, true)
 
 	if err != nil {


### PR DESCRIPTION
We occasionally get something like this:

	ERROR:
	  Code: Unknown
	  Message: SKR failed
	ERROR: Please refer to the documentation for more information on how to use this sidecar.
	...
	: retrieving authentication token failed: pulling http get authentication token response failed: Received invalid token. Please try again.
	: http response status equal to 500 Internal Server Error

"Received invalid token. Please try again." is an error from the ACI managed identity adapter. It's not clear why this happens but it does seems to be transient.  Therefore we work around it by doing retry on token fetching.