### PR TITLE
Fix README for attest package

### DIFF
--- a/pkg/attest/README.md
+++ b/pkg/attest/README.md
@@ -2,5 +2,5 @@ This package implements the Attest operation to fetch an attestation token from 
 It interacts with the following Azure services:
 - Microsoft Azure Attestation (maa): for issuing an attestation token given an attestation report signed by a key that is rooted to the cert chain and additional evidence including the blobs that have been hashed to the report's `HOST_DATA` and `REPORT_DATA` fields during virtual machine bringup and retrieval of the attestation report, respectively
 
-The attestation report is fetched from the platform security processor by executing the <parent>/tools/get-snp-report tool which is compiled and copied into the container's root filesystem under /bin.
+The attestation report is fetched from the platform security processor by ioctl syscalls directly to the /dev/sev (kernel 5.x) or /dev/sev-guest (kernel 6.x) device.
 


### PR DESCRIPTION
`pkg/attest/attestation_report_fetcher.go` implements in pure Go what `tools/get-snp-report` implements in C.