### PR TITLE
Update azure-cli to 2.80.0 (and migrate subscription)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/universal:linux",
 	"features": {
 		"ghcr.io/devcontainers/features/azure-cli:1": {
-			"version": "2.72.0"
+			"version": "2.80.0"
 		},
 		"ghcr.io/devcontainers/features/common-utils:2": {},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Install Azure CLI
         env:
-          AZ_CLI_VERSION: 2.74.0
+          AZ_CLI_VERSION: 2.80.0
         run: ./scripts/install-az-cli.sh
 
       - name: Setup Docker
@@ -214,7 +214,7 @@ jobs:
 
       - name: Install Azure CLI
         env:
-          AZ_CLI_VERSION: 2.74.0
+          AZ_CLI_VERSION: 2.80.0
         run: ./scripts/install-az-cli.sh
 
       - name: Setup Docker

--- a/scripts/install-az-cli.sh
+++ b/scripts/install-az-cli.sh
@@ -14,4 +14,4 @@ Components: main
 Architectures: $(dpkg --print-architecture)
 Signed-by: /etc/apt/keyrings/microsoft.gpg" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
 
-sudo apt-get install --allow-downgrades azure-cli=${AZ_CLI_VERSION:-2.72.0}-1~${AZ_DIST}
+sudo apt-get install --allow-downgrades azure-cli=${AZ_CLI_VERSION:-2.80.0}-1~${AZ_DIST}


### PR DESCRIPTION
This PR updates azure-cli to 2.80.0. At the same time, variables are changed to use the new subscription.