### PR TITLE
Don't test on eastus2euap

### DIFF
--- a/.github/workflows/test_canary.yml
+++ b/.github/workflows/test_canary.yml
@@ -1,4 +1,4 @@
-name: Test Canary
+name: Test other regions
 
 permissions:
   id-token: write
@@ -15,12 +15,12 @@ on:
       - .github/workflows/test_canary.yml
 
 jobs:
-  test-sidecars-eastus2euap:
-    name: East US 2 EUAP
-    uses: ./.github/workflows/ci.yml
-    secrets: inherit
-    with:
-      location: 'eastus2euap'
+  # test-sidecars-eastus2euap:
+  #   name: East US 2 EUAP
+  #   uses: ./.github/workflows/ci.yml
+  #   secrets: inherit
+  #   with:
+  #     location: 'eastus2euap'
 
   test-sidecars-uaenorth:
     name: UAE North


### PR DESCRIPTION
Rename the "Test Canary" workflow to "Test other regions" and just run in
uaenorth.