### PR TITLE
Reduce resource requirement for the test containergroup to 2 CPU and 3 GB RAM

### DIFF
--- a/tests/skr/skr.bicep
+++ b/tests/skr/skr.bicep
@@ -49,8 +49,8 @@ resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2023-05-01'
           ]
           resources: {
             requests: {
-              memoryInGB: 4
-              cpu: 1
+              memoryInGB: 1
+              cpu: json('0.5')
             }
           }
         }
@@ -67,8 +67,8 @@ resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2023-05-01'
           ]
           resources: {
             requests: {
-              memoryInGB: 4
-              cpu: 1
+              memoryInGB: 1
+              cpu: json('0.5')
             }
           }
         }
@@ -95,8 +95,8 @@ resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2023-05-01'
           ]
           resources: {
             requests: {
-              memoryInGB: 4
-              cpu: 1
+              memoryInGB: 1
+              cpu: json('0.5')
             }
           }
         }


### PR DESCRIPTION
This avoids capacity issues (and also saves cost).

Signed-off-by: Tingmao Wang <tingmaowang@microsoft.com>