### PR TITLE
Remove Trivy scan from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,20 +109,6 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
 
-    - name: Aqua Security Trivy
-      uses: aquasecurity/trivy-action@0.29.0
-      with:
-        scan-type: 'fs'
-        scan-ref: '.'
-        format: 'sarif'
-        output: 'trivy-results.sarif'
-        severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
-
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
-      with:
-        sarif_file: 'trivy-results.sarif'
-
   build:
     name: Go Build and Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
Removed Aqua Security Trivy scan steps from CI workflow.