### PR TITLE
Fix Windows ACI token resource encoding

### DIFF
--- a/pkg/common/token.go
+++ b/pkg/common/token.go
@@ -77,8 +77,12 @@ func newTokenRequest(resourceId string, identity Identity) (*http.Request, error
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing managed identity endpoint failed")
 	}
+	resource, err := url.QueryUnescape(resourceId)
+	if err != nil {
+		return nil, errors.Wrapf(err, "decoding managed identity resource failed")
+	}
 	query := uri.Query()
-	query.Set("resource", resourceId)
+	query.Set("resource", resource)
 	if useACIEndpoint {
 		query.Set("principalId", identity.PrincipalId)
 	} else if identity.ClientId != "" {

--- a/pkg/common/token_test.go
+++ b/pkg/common/token_test.go
@@ -101,6 +101,22 @@ func TestNewTokenRequest(t *testing.T) {
 	}
 }
 
+func TestNewTokenRequestDecodesResource(t *testing.T) {
+	t.Setenv(identityEndpoint, "http://10.0.0.1/token?api-version=2021-02-01")
+	t.Setenv(identityHeader, "header-secret")
+
+	request, err := newTokenRequest(
+		"https%3A%2F%2Fmanagedhsm.azure.net",
+		Identity{PrincipalId: "principal-id"},
+	)
+	if err != nil {
+		t.Fatalf("did not expect an error: %v", err)
+	}
+	if actual := request.URL.Query().Get("resource"); actual != "https://managedhsm.azure.net" {
+		t.Errorf("expected decoded resource, got %q", actual)
+	}
+}
+
 func Test_RedactMAAToken(t *testing.T) {
 	th := "e30."
 	testCases := [][2]string{


### PR DESCRIPTION
## Root cause
The Windows ACI token request path uses `url.Values.Encode`, but SKR passes already percent-encoded Key Vault and Managed HSM audiences. This encoded the percent signs a second time, causing the injected identity endpoint to return HTTP 500 during C-WCOW key release.

## Fix
Decode the supplied audience before adding it to the query and add a regression test using the actual Managed HSM value.

## Validation
- `go test ./pkg/common ./pkg/skr`
- Windows `cmd/skr` build
- ACR Windows build from commit `32c7e50`, published at `sha256:4e81b456f52b2d689d3a9b19c5d5abbc9d30c0ad6a947b35967308c1fca8e6d4`
- Live Germany North dashboard run https://github.com/microsoft/confidential-aci-dashboard/actions/runs/34103027206 passed all six C-WCOW SKR tests, including oct-HSM and EC-HSM release, with no Managed Identity token error